### PR TITLE
docs: add surveillance device signature format v1 JSON schema

### DIFF
--- a/schemas/examples/flock-raven-airtag.sigs.json
+++ b/schemas/examples/flock-raven-airtag.sigs.json
@@ -1,0 +1,235 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dougborg/AirHound/main/schemas/signatures.v1.schema.json",
+  "version": 1,
+  "signatures": [
+    {
+      "id": "flock-safety-oui",
+      "type": "mac_oui",
+      "oui": "B4:1E:52",
+      "description": "Flock Safety registered OUI"
+    },
+    {
+      "id": "silabs-588e81",
+      "type": "mac_oui",
+      "oui": "58:8E:81",
+      "description": "Silicon Labs (used by Flock Safety hardware)"
+    },
+    {
+      "id": "silabs-cccccc",
+      "type": "mac_oui",
+      "oui": "CC:CC:CC",
+      "description": "Silicon Labs"
+    },
+    {
+      "id": "flock-ssid-prefix",
+      "type": "wifi_ssid",
+      "match": "regex",
+      "value": "^Flock-[0-9A-Fa-f]{6}$",
+      "description": "Flock Safety camera WiFi AP (e.g. Flock-A1B2C3)"
+    },
+    {
+      "id": "fs-ext-battery-ssid",
+      "type": "wifi_ssid",
+      "match": "exact",
+      "value": "FS Ext Battery",
+      "description": "Flock Safety external battery WiFi"
+    },
+    {
+      "id": "flock-ssid-keyword",
+      "type": "wifi_ssid",
+      "match": "contains",
+      "value": "flock",
+      "case_sensitive": false,
+      "description": "Any SSID containing 'flock'"
+    },
+    {
+      "id": "flock-ble-name",
+      "type": "ble_name",
+      "match": "contains",
+      "value": "Flock",
+      "case_sensitive": false,
+      "description": "BLE device with 'Flock' in name"
+    },
+    {
+      "id": "fs-ext-battery-ble",
+      "type": "ble_name",
+      "match": "exact",
+      "value": "FS Ext Battery",
+      "description": "Flock Safety external battery BLE"
+    },
+    {
+      "id": "xuntong-mfr",
+      "type": "ble_manufacturer_id",
+      "company_id": 2504,
+      "description": "XUNTONG Technology (associated with Flock Safety)"
+    },
+    {
+      "id": "raven-gps-uuid",
+      "type": "ble_service_uuid",
+      "uuid": "3100",
+      "description": "Raven GPS service"
+    },
+    {
+      "id": "raven-power-uuid",
+      "type": "ble_service_uuid",
+      "uuid": "3200",
+      "description": "Raven Power service"
+    },
+    {
+      "id": "raven-network-uuid",
+      "type": "ble_service_uuid",
+      "uuid": "3300",
+      "description": "Raven Network service"
+    },
+    {
+      "id": "raven-upload-uuid",
+      "type": "ble_service_uuid",
+      "uuid": "3400",
+      "description": "Raven Upload service"
+    },
+    {
+      "id": "raven-error-uuid",
+      "type": "ble_service_uuid",
+      "uuid": "3500",
+      "description": "Raven Error service"
+    },
+    {
+      "id": "airtag-findmy-ad",
+      "type": "ble_ad_bytes",
+      "bytes": [
+        76,
+        0,
+        18,
+        25
+      ],
+      "offset": 0,
+      "description": "Apple FindMy / AirTag advertisement (company=Apple, type=0x12, len=0x19)"
+    },
+    {
+      "id": "flipper-zero-white",
+      "type": "ble_ad_bytes",
+      "bytes": [
+        128,
+        48
+      ],
+      "description": "Flipper Zero (White) BLE service data"
+    },
+    {
+      "id": "flipper-zero-black",
+      "type": "ble_ad_bytes",
+      "bytes": [
+        129,
+        48
+      ],
+      "description": "Flipper Zero (Black) BLE service data"
+    }
+  ],
+  "rules": [
+    {
+      "id": "flock-safety-camera",
+      "name": "Flock Safety Camera",
+      "description": "Flock Safety ALPR camera detected via WiFi or BLE",
+      "tags": [
+        "alpr",
+        "flock_safety"
+      ],
+      "detect": {
+        "anyOf": [
+          {
+            "sig": "flock-safety-oui"
+          },
+          {
+            "sig": "silabs-588e81"
+          },
+          {
+            "sig": "silabs-cccccc"
+          },
+          {
+            "sig": "flock-ssid-prefix"
+          },
+          {
+            "sig": "fs-ext-battery-ssid"
+          },
+          {
+            "sig": "flock-ssid-keyword"
+          },
+          {
+            "sig": "flock-ble-name"
+          },
+          {
+            "sig": "fs-ext-battery-ble"
+          },
+          {
+            "allOf": [
+              {
+                "sig": "xuntong-mfr"
+              },
+              {
+                "sig": "flock-ble-name"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "raven-acoustic-sensor",
+      "name": "Raven Acoustic Sensor",
+      "description": "ShotSpotter/Raven gunshot detection device",
+      "tags": [
+        "acoustic_sensor",
+        "raven"
+      ],
+      "detect": {
+        "anyOf": [
+          {
+            "sig": "raven-gps-uuid"
+          },
+          {
+            "sig": "raven-power-uuid"
+          },
+          {
+            "sig": "raven-network-uuid"
+          },
+          {
+            "sig": "raven-upload-uuid"
+          },
+          {
+            "sig": "raven-error-uuid"
+          }
+        ]
+      }
+    },
+    {
+      "id": "apple-airtag",
+      "name": "Apple AirTag",
+      "description": "Apple AirTag or FindMy-compatible tracker",
+      "tags": [
+        "tracker",
+        "apple"
+      ],
+      "detect": {
+        "sig": "airtag-findmy-ad"
+      }
+    },
+    {
+      "id": "flipper-zero",
+      "name": "Flipper Zero",
+      "description": "Flipper Zero multi-tool device",
+      "tags": [
+        "multi_tool",
+        "flipper"
+      ],
+      "detect": {
+        "anyOf": [
+          {
+            "sig": "flipper-zero-white"
+          },
+          {
+            "sig": "flipper-zero-black"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/schemas/signatures.v1.schema.json
+++ b/schemas/signatures.v1.schema.json
@@ -1,0 +1,386 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/dougborg/AirHound/main/schemas/signatures.v1.schema.json",
+  "title": "Surveillance Device Signature Format v1",
+  "description": "Portable interchange format for RF surveillance device signatures. Designed for cross-tool interoperability between AirHound, FlockOff, ESP32 Marauder, FlockSquawk, Flock-You, FlockBack, and similar projects.",
+  "type": "object",
+  "required": [
+    "version",
+    "signatures"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "Optional reference to this schema for editor validation."
+    },
+    "version": {
+      "const": 1,
+      "description": "Schema version. Must be 1 for this version of the format."
+    },
+    "signatures": {
+      "type": "array",
+      "description": "Array of atomic signature definitions. Each signature is a single, self-contained matching criterion. Implementations MUST validate that all signature id values are unique within this array.",
+      "items": {
+        "$ref": "#/$defs/signature"
+      },
+      "minItems": 1
+    },
+    "rules": {
+      "type": "array",
+      "description": "Array of detection rules. Each rule composes signatures with boolean logic into a named device detection. Implementations MUST validate that all rule id values are unique within this array.",
+      "items": {
+        "$ref": "#/$defs/rule"
+      }
+    }
+  },
+  "$defs": {
+    "signature_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*[a-z0-9]$",
+      "minLength": 2,
+      "maxLength": 64,
+      "description": "Unique identifier. Lowercase alphanumeric with hyphens and underscores."
+    },
+    "signature": {
+      "discriminator": {
+        "propertyName": "type"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/mac_oui"
+        },
+        {
+          "$ref": "#/$defs/wifi_ssid"
+        },
+        {
+          "$ref": "#/$defs/ble_name"
+        },
+        {
+          "$ref": "#/$defs/ble_service_uuid"
+        },
+        {
+          "$ref": "#/$defs/ble_manufacturer_id"
+        },
+        {
+          "$ref": "#/$defs/ble_ad_bytes"
+        }
+      ]
+    },
+    "mac_oui": {
+      "type": "object",
+      "description": "Match a device by the first 3 bytes (OUI) of its MAC address.",
+      "required": [
+        "id",
+        "type",
+        "oui"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/signature_id"
+        },
+        "type": {
+          "const": "mac_oui"
+        },
+        "oui": {
+          "type": "string",
+          "pattern": "^[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}$",
+          "description": "3-byte OUI prefix in colon-separated uppercase hex, e.g. \"B4:1E:52\"."
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "string_match": {
+      "type": "string",
+      "enum": [
+        "exact",
+        "prefix",
+        "contains",
+        "regex"
+      ],
+      "description": "String matching strategy. \"regex\" uses ECMA-262 (JavaScript) regular expressions for maximum portability."
+    },
+    "wifi_ssid": {
+      "type": "object",
+      "description": "Match a WiFi network by its SSID.",
+      "required": [
+        "id",
+        "type",
+        "match",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/signature_id"
+        },
+        "type": {
+          "const": "wifi_ssid"
+        },
+        "match": {
+          "$ref": "#/$defs/string_match"
+        },
+        "value": {
+          "type": "string",
+          "description": "The SSID string or pattern to match against."
+        },
+        "case_sensitive": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether the match is case-sensitive. Default: true."
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "ble_name": {
+      "type": "object",
+      "description": "Match a BLE device by its advertised local name.",
+      "required": [
+        "id",
+        "type",
+        "match",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/signature_id"
+        },
+        "type": {
+          "const": "ble_name"
+        },
+        "match": {
+          "$ref": "#/$defs/string_match"
+        },
+        "value": {
+          "type": "string",
+          "description": "The BLE local name string or pattern to match against."
+        },
+        "case_sensitive": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether the match is case-sensitive. Default: true."
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "ble_service_uuid": {
+      "type": "object",
+      "description": "Match a BLE device by an advertised service UUID.",
+      "required": [
+        "id",
+        "type",
+        "uuid"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/signature_id"
+        },
+        "type": {
+          "const": "ble_service_uuid"
+        },
+        "uuid": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{4}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+          "description": "BLE service UUID in lowercase hex. 4 chars for 16-bit (e.g. \"3100\"), or full 128-bit form (e.g. \"00003100-0000-1000-8000-00805f9b34fb\")."
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "ble_manufacturer_id": {
+      "type": "object",
+      "description": "Match a BLE device by its manufacturer-specific data company ID.",
+      "required": [
+        "id",
+        "type",
+        "company_id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/signature_id"
+        },
+        "type": {
+          "const": "ble_manufacturer_id"
+        },
+        "company_id": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535,
+          "description": "Bluetooth SIG assigned company identifier (16-bit). E.g. 2504 for XUNTONG."
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "ble_ad_bytes": {
+      "type": "object",
+      "description": "Match a BLE device by a raw byte pattern in its advertisement payload. Supports wildcard bytes for partial matching.",
+      "required": [
+        "id",
+        "type",
+        "bytes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/signature_id"
+        },
+        "type": {
+          "const": "ble_ad_bytes"
+        },
+        "bytes": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 255
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "minItems": 1,
+          "description": "Byte sequence to match. Integers (0-255) are exact; null is a wildcard matching any byte."
+        },
+        "offset": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Fixed byte offset into the advertisement payload. If omitted, the pattern is searched anywhere in the payload."
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "rule": {
+      "type": "object",
+      "description": "A detection rule that composes signatures into a named device detection using boolean logic.",
+      "required": [
+        "id",
+        "name",
+        "detect"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/signature_id",
+          "description": "Unique identifier for this rule."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable device name, e.g. \"Flock Safety Camera\"."
+        },
+        "description": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9_]+$"
+          },
+          "uniqueItems": true,
+          "description": "Freeform tags for categorization, e.g. [\"alpr\", \"flock_safety\"]."
+        },
+        "detect": {
+          "$ref": "#/$defs/expr",
+          "description": "Boolean expression tree over signature references."
+        }
+      }
+    },
+    "expr": {
+      "description": "A boolean expression node. Leaf nodes reference a signature by ID. Interior nodes combine children with anyOf (OR), allOf (AND), or not (negation).",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/expr_sig"
+        },
+        {
+          "$ref": "#/$defs/expr_any_of"
+        },
+        {
+          "$ref": "#/$defs/expr_all_of"
+        },
+        {
+          "$ref": "#/$defs/expr_not"
+        }
+      ]
+    },
+    "expr_sig": {
+      "type": "object",
+      "description": "Leaf: matches if the referenced signature matches the scan input.",
+      "required": [
+        "sig"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "sig": {
+          "$ref": "#/$defs/signature_id",
+          "description": "References a signature by its id. Implementations MUST validate that this references a defined signature in the signatures array."
+        }
+      }
+    },
+    "expr_any_of": {
+      "type": "object",
+      "description": "Logical OR: matches if ANY child expression matches.",
+      "required": [
+        "anyOf"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/expr"
+          },
+          "minItems": 2
+        }
+      }
+    },
+    "expr_all_of": {
+      "type": "object",
+      "description": "Logical AND: matches if ALL child expressions match.",
+      "required": [
+        "allOf"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "allOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/expr"
+          },
+          "minItems": 2
+        }
+      }
+    },
+    "expr_not": {
+      "type": "object",
+      "description": "Logical NOT: matches if the child expression does NOT match. Useful for excluding false positives.",
+      "required": [
+        "not"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/expr"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add formal JSON Schema (draft 2020-12) for the portable surveillance device signature interchange format:

- **`schemas/signatures.v1.schema.json`** — 6 signature types + detection rules with boolean expression trees
- **`schemas/examples/flock-raven-airtag.sigs.json`** — Example file demonstrating all signature types and rule composition

This is the canonical machine-readable spec for the signature format documented in #11. Issue #11 will be updated to reference these files instead of inlining the full schema content.

## Signature types

| Type | Key Fields | Description |
|------|-----------|-------------|
| `mac_oui` | `oui` | 3-byte MAC OUI prefix |
| `wifi_ssid` | `match`, `value` | SSID matching (exact/prefix/contains/regex) |
| `ble_name` | `match`, `value` | BLE local name matching |
| `ble_service_uuid` | `uuid` | 16-bit or 128-bit service UUID |
| `ble_manufacturer_id` | `company_id` | Bluetooth SIG company ID |
| `ble_ad_bytes` | `bytes`, `offset` | Raw advertisement byte pattern with wildcards |

## Detection rules

Rules compose signatures using recursive boolean expressions (`anyOf`, `allOf`, `not`). The example file includes rules for Flock Safety cameras, Raven acoustic sensors, Apple AirTags, and Flipper Zero devices.

## Depends on

- #21 (`docs/wire-protocol-schema`) — wire protocol schemas
- #20 (`build/jsonschema-tooling`) — CI validation and formatting recipes

## Test plan

- [ ] `just check-json` passes
- [ ] `just check-schemas` validates the signature schema against JSON Schema metaschema
- [ ] `just check-examples` validates the example file against `signatures.v1.schema.json`
- [ ] Schema matches the format documented in #11

Refs: #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)