### PR TITLE
security: harden CI pipeline and repository protections

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,18 +1,30 @@
 #!/bin/sh
 set -e
 
-# 1. Check for accidental secrets (fast, run first)
-if git diff --cached --name-only | grep -qE '\.(env|pem|key)$'; then
+# 1. Check for accidental secrets — filenames
+if git diff --cached --name-only | grep -qiE '\.(env|pem|key|p12|pfx|jks|keystore)$|credentials\.json|service-account.*\.json'; then
     echo "ERROR: Potentially sensitive file staged. Remove before committing."
     exit 1
 fi
 
-# 2. Auto-format all staged .rs files and re-stage them
+# 2. Check for accidental secrets — file content patterns
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=d | grep -vE '\.(bin|elf|png|jpg|gif|ico|woff2?|ttf)$' || true)
+if [ -n "$STAGED_FILES" ]; then
+    # Check staged content (not working tree) for secret patterns
+    if echo "$STAGED_FILES" | xargs git diff --cached -- | grep -qE \
+        '(AKIA[0-9A-Z]{16}|-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----|ghp_[0-9a-zA-Z]{36}|glpat-[0-9a-zA-Z\-_]{20}|sk-[0-9a-zA-Z]{48})'; then
+        echo "ERROR: Potential secret detected in staged content (AWS key, private key, or API token)."
+        echo "If this is a false positive, use 'git commit --no-verify' to bypass."
+        exit 1
+    fi
+fi
+
+# 3. Auto-format all staged .rs files and re-stage them
 STAGED_RS=$(git diff --cached --name-only --diff-filter=d | grep '\.rs$' || true)
 if [ -n "$STAGED_RS" ]; then
     echo "$STAGED_RS" | RUSTUP_TOOLCHAIN=nightly xargs cargo fmt --
     echo "$STAGED_RS" | xargs git add
 fi
 
-# 3. Run unit tests (can't auto-fix, must pass)
+# 4. Run unit tests (can't auto-fix, must pass)
 cargo test --lib --no-default-features --quiet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default: repo owner reviews all changes
+* @dougborg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,18 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
 
   fmt:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
         with:
           components: rustfmt
       - run: cargo fmt --check
@@ -33,10 +35,28 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
       - run: cargo test --lib --no-default-features
+        env:
+          RUSTUP_TOOLCHAIN: nightly
+
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+        env:
+          RUSTUP_TOOLCHAIN: nightly
+      - name: Audit dependencies
+        run: cargo audit
         env:
           RUSTUP_TOOLCHAIN: nightly
 
@@ -60,7 +80,7 @@ jobs:
             chip: esp32
             features: m5stickc
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build ${{ matrix.name }}
         run: |
@@ -68,7 +88,7 @@ jobs:
           . /home/esp/export-esp.sh
           cargo build --no-default-features --features ${{ matrix.features }} --release --target ${{ matrix.target }} -Z build-std=core,alloc
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: elf-${{ matrix.name }}
           path: target/${{ matrix.target }}/release/airhound
@@ -82,17 +102,17 @@ jobs:
       WOKWI_CLI_TOKEN: ${{ secrets.WOKWI_CLI_TOKEN }}
     steps:
       - if: env.WOKWI_CLI_TOKEN != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - if: env.WOKWI_CLI_TOKEN != ''
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: elf-m5stickc
           path: target/xtensa-esp32-none-elf/release/
 
       - name: Simulate firmware
         if: env.WOKWI_CLI_TOKEN != ''
-        uses: wokwi/wokwi-ci-action@v1
+        uses: wokwi/wokwi-ci-action@11ddc3fe66a14fcd46683fb21ae5c77657ad4606 # v1
         with:
           token: ${{ secrets.WOKWI_CLI_TOKEN }}
           timeout: 10000
@@ -110,19 +130,19 @@ jobs:
           - name: m5stickc
             chip: esp32
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@7691a5b29cda4f5499b819e5618012ba4b6c3334 # main
 
       - name: Install espflash
         run: cargo binstall espflash --no-confirm
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: elf-${{ matrix.name }}
 
       - name: Create flashable binary
         run: espflash save-image --chip ${{ matrix.chip }} airhound airhound-${{ matrix.name }}.bin
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: bin-${{ matrix.name }}
           path: airhound-${{ matrix.name }}.bin
@@ -135,7 +155,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           message: |
             ### Preview Binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
         with:
           config-file: release-please-config.json
@@ -43,7 +43,7 @@ jobs:
             chip: esp32
             features: m5stickc
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build ${{ matrix.name }}
         run: |
@@ -57,7 +57,7 @@ jobs:
           . /home/esp/export-esp.sh
           espflash save-image --chip ${{ matrix.chip }} target/${{ matrix.target }}/release/airhound airhound-${{ matrix.name }}.bin
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: release-bin-${{ matrix.name }}
           path: airhound-${{ matrix.name }}.bin
@@ -68,12 +68,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: release-bin-*
           merge-multiple: true
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: "*.bin"

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,15 @@
 .DS_Store
 Thumbs.db
 
-# Secrets
+# Secrets and credentials
 .env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks
+*.keystore
+credentials.json
+service-account*.json
+**/secrets/


### PR DESCRIPTION
## Summary

- **Pin all GitHub Actions to commit SHAs** — prevents supply chain attacks via tag mutation (every action has a `# v6` comment for readability)
- **Add `cargo audit` CI job** — checks dependencies for known vulnerabilities on every push/PR
- **Explicit least-privilege permissions** — `fmt`, `test`, `audit` jobs now declare `contents: read` instead of inheriting defaults
- **Expand `.gitignore`** — covers `*.pem`, `*.key`, `*.p12`, `*.pfx`, `credentials.json`, `service-account*.json`
- **Expand pre-commit secret detection** — scans staged file content for AWS access keys (`AKIA...`), private key headers, GitHub/GitLab tokens (was filename-only)
- **Add `CODEOWNERS`** — `@dougborg` reviews all changes
- **Branch ruleset for `main`** (created via API, already active) — requires PR, requires `fmt` + `test` + both `build` checks to pass, dismisses stale reviews

## Test plan

- [ ] CI runs on this PR and all new/modified jobs pass
- [ ] `cargo audit` job completes (may report advisories for git deps — that's expected)
- [ ] Verify ruleset is active: `gh ruleset list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)