### PR TITLE
feat: boolean rule composition engine and ble_ad_bytes matching

### DIFF
--- a/firmware-std/src/main.rs
+++ b/firmware-std/src/main.rs
@@ -370,6 +370,7 @@ fn handle_wifi_event(
         ch: wifi.channel,
         frame: wifi.frame_type.as_str(),
         matches: &result.matches,
+        rule: result.rule_names.first().copied(),
         ts,
     };
 
@@ -393,6 +394,7 @@ fn handle_ble_event(
         rssi: ble.rssi,
         service_uuids_16: &ble.service_uuids_16,
         manufacturer_id: ble.manufacturer_id,
+        raw_ad: &ble.raw_ad,
     };
 
     let result = filter_ble(&input, config);
@@ -424,6 +426,7 @@ fn handle_ble_event(
         uuid: None,
         mfr: ble.manufacturer_id,
         matches: &result.matches,
+        rule: result.rule_names.first().copied(),
         ts,
     };
 

--- a/src/comm.rs
+++ b/src/comm.rs
@@ -213,6 +213,7 @@ mod tests {
             ch: 1,
             frame: "beacon",
             matches: &matches,
+            rule: None,
             ts: 100,
         };
         let mut buf = [0u8; 512];

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -189,6 +189,195 @@ pub static BLE_MANUFACTURER_IDS: &[u16] = &[
     0x09C8, // XUNTONG (associated with Flock Safety)
 ];
 
+/// A BLE advertisement byte pattern signature.
+pub struct BleAdBytesPattern {
+    /// Byte sequence to match
+    pub bytes: &'static [u8],
+    /// Match position: `None` = search anywhere in raw AD data,
+    /// `Some(n)` = match at manufacturer-specific data offset `n`
+    pub offset: Option<usize>,
+    /// Human-readable description
+    pub description: &'static str,
+}
+
+/// Known BLE advertisement byte patterns.
+///
+/// Patterns for tracker and multi-tool devices that can be identified
+/// by specific byte sequences in their advertisement data.
+pub static BLE_AD_BYTES_PATTERNS: &[BleAdBytesPattern] = &[
+    // Apple AirTag / FindMy: manufacturer data starts with Apple company ID (0x004C)
+    // followed by FindMy type byte 0x12 and length 0x19
+    BleAdBytesPattern {
+        bytes: &[0x4C, 0x00, 0x12, 0x19],
+        offset: Some(0),
+        description: "Apple AirTag",
+    },
+    // Flipper Zero White: [0x80, 0x30] in manufacturer-specific data
+    BleAdBytesPattern {
+        bytes: &[0x80, 0x30],
+        offset: None,
+        description: "Flipper Zero",
+    },
+    // Flipper Zero Black: [0x81, 0x30] in manufacturer-specific data
+    BleAdBytesPattern {
+        bytes: &[0x81, 0x30],
+        offset: None,
+        description: "Flipper Zero",
+    },
+];
+
+// ── Signature index constants ────────────────────────────────────────
+//
+// Each compiled-in signature array gets a starting index. The global index
+// of signature `i` within array `A` is `SIG_IDX_A_START + i`. These map
+// every compiled-in signature to a unique `SigIdx` for the rule engine.
+
+use crate::rules::{ExprNode, Rule, RuleDb, SigIdx};
+
+pub const SIG_IDX_MAC_OUI_START: SigIdx = 0;
+pub const SIG_IDX_SSID_PATTERN_START: SigIdx = MAC_PREFIXES.len() as SigIdx;
+pub const SIG_IDX_SSID_EXACT_START: SigIdx =
+    SIG_IDX_SSID_PATTERN_START + SSID_PATTERNS.len() as SigIdx;
+pub const SIG_IDX_SSID_KEYWORD_START: SigIdx =
+    SIG_IDX_SSID_EXACT_START + SSID_EXACT.len() as SigIdx;
+pub const SIG_IDX_WIFI_NAME_START: SigIdx =
+    SIG_IDX_SSID_KEYWORD_START + SSID_KEYWORDS.len() as SigIdx;
+pub const SIG_IDX_BLE_NAME_START: SigIdx =
+    SIG_IDX_WIFI_NAME_START + WIFI_NAME_KEYWORDS.len() as SigIdx;
+pub const SIG_IDX_BLE_UUID_START: SigIdx =
+    SIG_IDX_BLE_NAME_START + BLE_NAME_PATTERNS.len() as SigIdx;
+pub const SIG_IDX_BLE_STD_UUID_START: SigIdx =
+    SIG_IDX_BLE_UUID_START + BLE_SERVICE_UUIDS_16.len() as SigIdx;
+pub const SIG_IDX_BLE_MFR_START: SigIdx =
+    SIG_IDX_BLE_STD_UUID_START + BLE_STANDARD_UUIDS_16.len() as SigIdx;
+pub const SIG_IDX_BLE_AD_BYTES_START: SigIdx =
+    SIG_IDX_BLE_MFR_START + BLE_MANUFACTURER_IDS.len() as SigIdx;
+
+/// Total number of compiled-in signatures.
+pub const SIG_COUNT: usize = SIG_IDX_BLE_AD_BYTES_START as usize + BLE_AD_BYTES_PATTERNS.len();
+
+// ── Named signature indices (for readability in rule definitions) ────
+
+// Flock Safety Camera signatures
+/// MAC_PREFIXES[0] = Flock Safety OUI B4:1E:52
+const SIG_FLOCK_SAFETY_OUI: SigIdx = SIG_IDX_MAC_OUI_START + 0;
+/// MAC_PREFIXES[1] = Silicon Labs 58:8E:81
+const SIG_SILABS_588E81: SigIdx = SIG_IDX_MAC_OUI_START + 1;
+/// MAC_PREFIXES[2] = Silicon Labs CC:CC:CC
+const SIG_SILABS_CCCCCC: SigIdx = SIG_IDX_MAC_OUI_START + 2;
+/// SSID_PATTERNS[0] = Flock-XXXXXX
+const SIG_FLOCK_SSID_PREFIX: SigIdx = SIG_IDX_SSID_PATTERN_START + 0;
+/// SSID_EXACT[0] = "FS Ext Battery"
+const SIG_FS_EXT_BATTERY_SSID: SigIdx = SIG_IDX_SSID_EXACT_START + 0;
+/// SSID_KEYWORDS[0] = "flock"
+const SIG_FLOCK_SSID_KEYWORD: SigIdx = SIG_IDX_SSID_KEYWORD_START + 0;
+/// BLE_NAME_PATTERNS[0] = "Flock"
+const SIG_FLOCK_BLE_NAME: SigIdx = SIG_IDX_BLE_NAME_START + 0;
+/// BLE_NAME_PATTERNS[2] = "FS Ext Battery"
+const SIG_FS_EXT_BATTERY_BLE: SigIdx = SIG_IDX_BLE_NAME_START + 2;
+/// BLE_MANUFACTURER_IDS[0] = 0x09C8 (XUNTONG)
+const SIG_XUNTONG_MFR: SigIdx = SIG_IDX_BLE_MFR_START + 0;
+
+// Raven Acoustic Sensor signatures
+/// BLE_SERVICE_UUIDS_16[0] = 0x3100
+const SIG_RAVEN_GPS_UUID: SigIdx = SIG_IDX_BLE_UUID_START + 0;
+/// BLE_SERVICE_UUIDS_16[1] = 0x3200
+const SIG_RAVEN_POWER_UUID: SigIdx = SIG_IDX_BLE_UUID_START + 1;
+/// BLE_SERVICE_UUIDS_16[2] = 0x3300
+const SIG_RAVEN_NETWORK_UUID: SigIdx = SIG_IDX_BLE_UUID_START + 2;
+/// BLE_SERVICE_UUIDS_16[3] = 0x3400
+const SIG_RAVEN_UPLOAD_UUID: SigIdx = SIG_IDX_BLE_UUID_START + 3;
+/// BLE_SERVICE_UUIDS_16[4] = 0x3500
+const SIG_RAVEN_ERROR_UUID: SigIdx = SIG_IDX_BLE_UUID_START + 4;
+
+// Apple AirTag signature
+/// BLE_AD_BYTES_PATTERNS[0] = Apple FindMy header
+const SIG_AIRTAG_FINDMY_AD: SigIdx = SIG_IDX_BLE_AD_BYTES_START + 0;
+
+// Flipper Zero signatures
+/// BLE_AD_BYTES_PATTERNS[1] = Flipper Zero White
+const SIG_FLIPPER_ZERO_WHITE: SigIdx = SIG_IDX_BLE_AD_BYTES_START + 1;
+/// BLE_AD_BYTES_PATTERNS[2] = Flipper Zero Black
+const SIG_FLIPPER_ZERO_BLACK: SigIdx = SIG_IDX_BLE_AD_BYTES_START + 2;
+
+// ── Compiled-in rule database ───────────────────────────────────────
+
+/// Shared post-order expression node pool for all rules.
+///
+/// Layout:
+///   [0..12)  Flock Safety Camera (12 nodes)
+///   [12..18) Raven Acoustic Sensor (6 nodes)
+///   [18]     Apple AirTag (1 node)
+///   [19..22) Flipper Zero (3 nodes)
+static DEFAULT_RULE_NODES: &[ExprNode] = &[
+    // ── Flock Safety Camera ──
+    // anyOf(
+    //   flock-safety-oui, silabs-588e81, silabs-cccccc,
+    //   flock-ssid-prefix, fs-ext-battery-ssid, flock-ssid-keyword,
+    //   flock-ble-name, fs-ext-battery-ble,
+    //   allOf(xuntong-mfr, flock-ble-name)
+    // )
+    ExprNode::Sig(SIG_FLOCK_SAFETY_OUI),    // [0]
+    ExprNode::Sig(SIG_SILABS_588E81),       // [1]
+    ExprNode::Sig(SIG_SILABS_CCCCCC),       // [2]
+    ExprNode::Sig(SIG_FLOCK_SSID_PREFIX),   // [3]
+    ExprNode::Sig(SIG_FS_EXT_BATTERY_SSID), // [4]
+    ExprNode::Sig(SIG_FLOCK_SSID_KEYWORD),  // [5]
+    ExprNode::Sig(SIG_FLOCK_BLE_NAME),      // [6]
+    ExprNode::Sig(SIG_FS_EXT_BATTERY_BLE),  // [7]
+    // allOf(xuntong-mfr, flock-ble-name) — nested AND
+    ExprNode::Sig(SIG_XUNTONG_MFR),    // [8]
+    ExprNode::Sig(SIG_FLOCK_BLE_NAME), // [9]  (same sig referenced again)
+    ExprNode::AllOf { count: 2 },      // [10]
+    // Top-level anyOf: 8 direct sigs + 1 allOf result = 9 children
+    ExprNode::AnyOf { count: 9 }, // [11]
+    // ── Raven Acoustic Sensor ──
+    // anyOf(raven-gps, raven-power, raven-network, raven-upload, raven-error)
+    ExprNode::Sig(SIG_RAVEN_GPS_UUID),     // [12]
+    ExprNode::Sig(SIG_RAVEN_POWER_UUID),   // [13]
+    ExprNode::Sig(SIG_RAVEN_NETWORK_UUID), // [14]
+    ExprNode::Sig(SIG_RAVEN_UPLOAD_UUID),  // [15]
+    ExprNode::Sig(SIG_RAVEN_ERROR_UUID),   // [16]
+    ExprNode::AnyOf { count: 5 },          // [17]
+    // ── Apple AirTag ──
+    // Single sig reference
+    ExprNode::Sig(SIG_AIRTAG_FINDMY_AD), // [18]
+    // ── Flipper Zero ──
+    // anyOf(flipper-white, flipper-black)
+    ExprNode::Sig(SIG_FLIPPER_ZERO_WHITE), // [19]
+    ExprNode::Sig(SIG_FLIPPER_ZERO_BLACK), // [20]
+    ExprNode::AnyOf { count: 2 },          // [21]
+];
+
+static DEFAULT_RULES: &[Rule] = &[
+    Rule {
+        name: "Flock Safety Camera",
+        expr_start: 0,
+        expr_len: 12,
+    },
+    Rule {
+        name: "Raven Acoustic Sensor",
+        expr_start: 12,
+        expr_len: 6,
+    },
+    Rule {
+        name: "Apple AirTag",
+        expr_start: 18,
+        expr_len: 1,
+    },
+    Rule {
+        name: "Flipper Zero",
+        expr_start: 19,
+        expr_len: 3,
+    },
+];
+
+/// The default compiled-in rule database.
+pub static DEFAULT_RULE_DB: RuleDb = RuleDb {
+    nodes: DEFAULT_RULE_NODES,
+    rules: DEFAULT_RULES,
+};
+
 /// SSID suffix format kind
 #[derive(Debug, Clone, Copy)]
 pub enum SuffixKind {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -6,10 +6,11 @@
 use heapless::Vec;
 
 use crate::defaults::{
-    self, BLE_MANUFACTURER_IDS, BLE_NAME_PATTERNS, BLE_SERVICE_UUIDS_16, MAC_PREFIXES, SSID_EXACT,
-    SSID_KEYWORDS, SSID_PATTERNS, WIFI_NAME_KEYWORDS,
+    self, BLE_AD_BYTES_PATTERNS, BLE_MANUFACTURER_IDS, BLE_NAME_PATTERNS, BLE_SERVICE_UUIDS_16,
+    MAC_PREFIXES, SSID_EXACT, SSID_KEYWORDS, SSID_PATTERNS, WIFI_NAME_KEYWORDS,
 };
 use crate::protocol::{MatchDetail, MatchReason};
+use crate::rules::{evaluate_rules, RuleDb, SigMatchSet};
 
 /// Runtime filter configuration. Allows the companion app to adjust
 /// filtering without reflashing.
@@ -55,6 +56,8 @@ pub struct BleScanInput<'a> {
     pub service_uuids_16: &'a [u16],
     /// Manufacturer company ID (0 if not present)
     pub manufacturer_id: u16,
+    /// Raw advertisement data bytes for byte-pattern matching
+    pub raw_ad: &'a [u8],
 }
 
 /// Result of filter evaluation
@@ -63,6 +66,10 @@ pub struct FilterResult {
     pub matched: bool,
     /// Up to 4 match reasons
     pub matches: Vec<MatchReason, 4>,
+    /// Bitset of which signature indices matched (for rule evaluation)
+    pub sig_matches: SigMatchSet,
+    /// Names of matched rules (populated by `filter_*_with_rules`)
+    pub rule_names: Vec<&'static str, 4>,
 }
 
 impl FilterResult {
@@ -70,6 +77,8 @@ impl FilterResult {
         Self {
             matched: false,
             matches: Vec::new(),
+            sig_matches: SigMatchSet::new(),
+            rule_names: Vec::new(),
         }
     }
 
@@ -109,15 +118,21 @@ pub fn filter_wifi(input: &WiFiScanInput, config: &FilterConfig) -> FilterResult
     check_mac_oui(input.mac, &mut result);
 
     // SSID structured pattern check (e.g., Flock-XXXXXX)
-    for pattern in SSID_PATTERNS {
+    for (i, pattern) in SSID_PATTERNS.iter().enumerate() {
         if pattern.matches(input.ssid) {
+            result
+                .sig_matches
+                .set(defaults::SIG_IDX_SSID_PATTERN_START + i as u16);
             result.add_match("ssid_pattern", pattern.description);
         }
     }
 
     // SSID exact match check
-    for &exact in SSID_EXACT {
+    for (i, &exact) in SSID_EXACT.iter().enumerate() {
         if input.ssid == exact {
+            result
+                .sig_matches
+                .set(defaults::SIG_IDX_SSID_EXACT_START + i as u16);
             result.add_match("ssid_exact", exact);
         }
     }
@@ -131,15 +146,21 @@ pub fn filter_wifi(input: &WiFiScanInput, config: &FilterConfig) -> FilterResult
         .collect();
     let ssid_lower_str = core::str::from_utf8(&ssid_lower).unwrap_or("");
 
-    for &keyword in SSID_KEYWORDS {
+    for (i, &keyword) in SSID_KEYWORDS.iter().enumerate() {
         if ssid_lower_str.contains(keyword) {
+            result
+                .sig_matches
+                .set(defaults::SIG_IDX_SSID_KEYWORD_START + i as u16);
             result.add_match("ssid_keyword", keyword);
         }
     }
 
     // WiFi name keyword check (from FlockOff — matches partial names)
-    for &keyword in WIFI_NAME_KEYWORDS {
+    for (i, &keyword) in WIFI_NAME_KEYWORDS.iter().enumerate() {
         if ssid_lower_str.contains(keyword) {
+            result
+                .sig_matches
+                .set(defaults::SIG_IDX_WIFI_NAME_START + i as u16);
             // Only add if not already matched by SSID_KEYWORDS
             if !SSID_KEYWORDS.contains(&keyword) {
                 result.add_match("wifi_name", keyword);
@@ -176,7 +197,7 @@ pub fn filter_ble(input: &BleScanInput, config: &FilterConfig) -> FilterResult {
             .collect();
         let name_lower_str = core::str::from_utf8(&name_lower).unwrap_or("");
 
-        for &pattern in BLE_NAME_PATTERNS {
+        for (i, &pattern) in BLE_NAME_PATTERNS.iter().enumerate() {
             let pattern_lower: Vec<u8, 33> = pattern
                 .bytes()
                 .take(33)
@@ -185,6 +206,9 @@ pub fn filter_ble(input: &BleScanInput, config: &FilterConfig) -> FilterResult {
             let pattern_lower_str = core::str::from_utf8(&pattern_lower).unwrap_or("");
 
             if name_lower_str.contains(pattern_lower_str) {
+                result
+                    .sig_matches
+                    .set(defaults::SIG_IDX_BLE_NAME_START + i as u16);
                 result.add_match("ble_name", pattern);
             }
         }
@@ -192,31 +216,145 @@ pub fn filter_ble(input: &BleScanInput, config: &FilterConfig) -> FilterResult {
 
     // BLE service UUID check (16-bit)
     for &uuid in input.service_uuids_16 {
-        if BLE_SERVICE_UUIDS_16.contains(&uuid) {
-            result.add_match("ble_uuid", "Raven service UUID");
+        for (i, &known) in BLE_SERVICE_UUIDS_16.iter().enumerate() {
+            if uuid == known {
+                result
+                    .sig_matches
+                    .set(defaults::SIG_IDX_BLE_UUID_START + i as u16);
+                result.add_match("ble_uuid", "Raven service UUID");
+            }
         }
-        if defaults::BLE_STANDARD_UUIDS_16.contains(&uuid) {
-            result.add_match("ble_uuid_std", "Raven standard UUID");
+        for (i, &known) in defaults::BLE_STANDARD_UUIDS_16.iter().enumerate() {
+            if uuid == known {
+                result
+                    .sig_matches
+                    .set(defaults::SIG_IDX_BLE_STD_UUID_START + i as u16);
+                result.add_match("ble_uuid_std", "Raven standard UUID");
+            }
         }
     }
 
     // BLE manufacturer ID check
     if input.manufacturer_id != 0 {
-        if BLE_MANUFACTURER_IDS.contains(&input.manufacturer_id) {
-            result.add_match("ble_mfr", "Known manufacturer ID");
+        for (i, &known) in BLE_MANUFACTURER_IDS.iter().enumerate() {
+            if input.manufacturer_id == known {
+                result
+                    .sig_matches
+                    .set(defaults::SIG_IDX_BLE_MFR_START + i as u16);
+                result.add_match("ble_mfr", "Known manufacturer ID");
+                break;
+            }
         }
+    }
+
+    // BLE advertisement byte pattern check
+    if !input.raw_ad.is_empty() {
+        check_ble_ad_bytes(input.raw_ad, &mut result);
     }
 
     result
 }
 
+/// Evaluate a WiFi scan event against signatures and then against rules.
+pub fn filter_wifi_with_rules(
+    input: &WiFiScanInput,
+    config: &FilterConfig,
+    db: &RuleDb,
+) -> FilterResult {
+    let mut result = filter_wifi(input, config);
+    apply_rules(&mut result, db);
+    result
+}
+
+/// Evaluate a BLE scan event against signatures and then against rules.
+pub fn filter_ble_with_rules(
+    input: &BleScanInput,
+    config: &FilterConfig,
+    db: &RuleDb,
+) -> FilterResult {
+    let mut result = filter_ble(input, config);
+    apply_rules(&mut result, db);
+    result
+}
+
+/// Run rule evaluation on a filter result and populate `rule_names`.
+fn apply_rules(result: &mut FilterResult, db: &RuleDb) {
+    if !result.matched {
+        return;
+    }
+    let matched_indices = evaluate_rules(db, &result.sig_matches);
+    for &idx in &matched_indices {
+        if let Some(rule) = db.rules.get(idx as usize) {
+            let _ = result.rule_names.push(rule.name);
+        }
+    }
+}
+
 /// Check MAC address against known OUI prefixes
 fn check_mac_oui(mac: &[u8; 6], result: &mut FilterResult) {
     let oui = [mac[0], mac[1], mac[2]];
-    for &(ref prefix, vendor) in MAC_PREFIXES {
+    for (i, &(ref prefix, vendor)) in MAC_PREFIXES.iter().enumerate() {
         if oui == *prefix {
+            result
+                .sig_matches
+                .set(defaults::SIG_IDX_MAC_OUI_START + i as u16);
             result.add_match("mac_oui", vendor);
             return; // Only report first match (a MAC can only match one OUI)
+        }
+    }
+}
+
+/// Extract manufacturer-specific data sections from raw AD bytes.
+///
+/// AD type 0xFF = manufacturer-specific data. The data after the type byte
+/// contains the company ID (2 bytes LE) followed by manufacturer payload.
+/// We return the full data portion (including company ID bytes) for pattern matching.
+fn find_manufacturer_data(raw_ad: &[u8]) -> Option<&[u8]> {
+    let mut pos = 0;
+    while pos < raw_ad.len() {
+        let len = raw_ad[pos] as usize;
+        if len == 0 || pos + 1 + len > raw_ad.len() {
+            break;
+        }
+        let ad_type = raw_ad[pos + 1];
+        if ad_type == 0xFF {
+            return Some(&raw_ad[pos + 2..pos + 1 + len]);
+        }
+        pos += 1 + len;
+    }
+    None
+}
+
+/// Check raw BLE advertisement data against known byte patterns.
+fn check_ble_ad_bytes(raw_ad: &[u8], result: &mut FilterResult) {
+    let mfr_data = find_manufacturer_data(raw_ad);
+
+    for (i, pattern) in BLE_AD_BYTES_PATTERNS.iter().enumerate() {
+        if pattern.bytes.is_empty() {
+            continue;
+        }
+        let matched = match pattern.offset {
+            Some(offset) => {
+                // Fixed offset match within manufacturer-specific data
+                if let Some(data) = mfr_data {
+                    data.len() >= offset + pattern.bytes.len()
+                        && data[offset..offset + pattern.bytes.len()] == *pattern.bytes
+                } else {
+                    false
+                }
+            }
+            None => {
+                // Search anywhere in raw AD data
+                raw_ad
+                    .windows(pattern.bytes.len())
+                    .any(|w| w == pattern.bytes)
+            }
+        };
+        if matched {
+            result
+                .sig_matches
+                .set(defaults::SIG_IDX_BLE_AD_BYTES_START + i as u16);
+            result.add_match("ble_ad_bytes", pattern.description);
         }
     }
 }
@@ -416,6 +554,7 @@ mod tests {
             rssi: -50,
             service_uuids_16: &[],
             manufacturer_id: 0,
+            raw_ad: &[],
         };
         let result = filter_ble(&input, &config);
         assert!(result.matched);
@@ -431,6 +570,7 @@ mod tests {
             rssi: -50,
             service_uuids_16: &[],
             manufacturer_id: 0,
+            raw_ad: &[],
         };
         let result = filter_ble(&input, &config);
         assert!(result.matched);
@@ -445,6 +585,7 @@ mod tests {
             rssi: -50,
             service_uuids_16: &[],
             manufacturer_id: 0,
+            raw_ad: &[],
         };
         let result = filter_ble(&input, &config);
         assert!(result.matched);
@@ -459,6 +600,7 @@ mod tests {
             rssi: -50,
             service_uuids_16: &[],
             manufacturer_id: 0x09C8,
+            raw_ad: &[],
         };
         let result = filter_ble(&input, &config);
         assert!(result.matched);
@@ -474,6 +616,7 @@ mod tests {
             rssi: -50,
             service_uuids_16: &[0x3100], // Raven GPS service
             manufacturer_id: 0,
+            raw_ad: &[],
         };
         let result = filter_ble(&input, &config);
         assert!(result.matched);
@@ -489,6 +632,7 @@ mod tests {
             rssi: -50,
             service_uuids_16: &[0x1819], // Location and Navigation
             manufacturer_id: 0,
+            raw_ad: &[],
         };
         let result = filter_ble(&input, &config);
         assert!(result.matched);
@@ -507,6 +651,7 @@ mod tests {
             rssi: -50,
             service_uuids_16: &[0x180F], // Battery Service (not surveillance)
             manufacturer_id: 0x004C,     // Apple (not in our list)
+            raw_ad: &[],
         };
         let result = filter_ble(&input, &config);
         assert!(!result.matched);
@@ -524,6 +669,7 @@ mod tests {
             rssi: -50,
             service_uuids_16: &[],
             manufacturer_id: 0x09C8,
+            raw_ad: &[],
         };
         let result = filter_ble(&input, &config);
         assert!(!result.matched);
@@ -541,9 +687,688 @@ mod tests {
             rssi: -70,
             service_uuids_16: &[],
             manufacturer_id: 0,
+            raw_ad: &[],
         };
         let result = filter_ble(&input, &config);
         assert!(!result.matched);
+    }
+
+    // ── BLE AD bytes tests ────────────────────────────────────────
+
+    #[test]
+    fn ble_ad_bytes_airtag_findmy_matches() {
+        let config = default_config();
+        // Realistic AirTag AD: manufacturer-specific data with Apple FindMy header
+        // AD structure: len=0x1B, type=0xFF, data=[0x4C, 0x00, 0x12, 0x19, ...]
+        let raw_ad = [
+            0x1B, 0xFF, 0x4C, 0x00, 0x12, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0x004C,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble(&input, &config);
+        assert!(result.matched);
+        assert!(result
+            .matches
+            .iter()
+            .any(|m| m.filter_type == "ble_ad_bytes" && m.detail.as_str() == "Apple AirTag"));
+    }
+
+    #[test]
+    fn ble_ad_bytes_flipper_zero_white_matches() {
+        let config = default_config();
+        // AD containing Flipper Zero White bytes [0x80, 0x30] somewhere
+        let raw_ad = [
+            0x02, 0x01, 0x06, // Flags
+            0x05, 0xFF, 0x80, 0x30, 0x01, 0x02, // Manufacturer data with 0x80,0x30
+        ];
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble(&input, &config);
+        assert!(result.matched);
+        assert!(result
+            .matches
+            .iter()
+            .any(|m| m.filter_type == "ble_ad_bytes" && m.detail.as_str() == "Flipper Zero"));
+    }
+
+    #[test]
+    fn ble_ad_bytes_flipper_zero_black_matches() {
+        let config = default_config();
+        // Flipper Zero Black: [0x81, 0x30]
+        let raw_ad = [0x04, 0xFF, 0x81, 0x30, 0x01];
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble(&input, &config);
+        assert!(result.matched);
+        assert!(result
+            .matches
+            .iter()
+            .any(|m| m.filter_type == "ble_ad_bytes"));
+    }
+
+    #[test]
+    fn ble_ad_bytes_airtag_wrong_offset_no_match() {
+        let config = default_config();
+        // AirTag bytes at wrong position (not at start of manufacturer data)
+        // Manufacturer data: [0x00, 0x4C, 0x00, 0x12, 0x19] — offset by 1
+        let raw_ad = [0x06, 0xFF, 0x00, 0x4C, 0x00, 0x12, 0x19];
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble(&input, &config);
+        // Should NOT match AirTag (offset-sensitive pattern)
+        assert!(!result
+            .matches
+            .iter()
+            .any(|m| m.detail.as_str() == "Apple AirTag"));
+    }
+
+    #[test]
+    fn ble_ad_bytes_no_match_for_random_data() {
+        let config = default_config();
+        let raw_ad = [
+            0x02, 0x01, 0x06, // Flags
+            0x03, 0xFF, 0xAA, 0xBB, // Random manufacturer data
+        ];
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble(&input, &config);
+        assert!(!result
+            .matches
+            .iter()
+            .any(|m| m.filter_type == "ble_ad_bytes"));
+    }
+
+    #[test]
+    fn ble_ad_bytes_empty_raw_ad_no_match() {
+        let config = default_config();
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0,
+            raw_ad: &[],
+        };
+        let result = filter_ble(&input, &config);
+        assert!(!result
+            .matches
+            .iter()
+            .any(|m| m.filter_type == "ble_ad_bytes"));
+    }
+
+    // ── sig_matches bitset population tests ────────────────────────
+
+    #[test]
+    fn sig_matches_populated_for_wifi_mac_oui() {
+        let config = default_config();
+        let input = WiFiScanInput {
+            mac: &[0xB4, 0x1E, 0x52, 0x01, 0x02, 0x03], // Flock Safety OUI = index 0
+            ssid: "",
+            rssi: -50,
+        };
+        let result = filter_wifi(&input, &config);
+        assert!(result.sig_matches.get(defaults::SIG_IDX_MAC_OUI_START + 0));
+    }
+
+    #[test]
+    fn sig_matches_populated_for_wifi_ssid_pattern() {
+        let config = default_config();
+        let input = WiFiScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            ssid: "Flock-A1B2C3",
+            rssi: -50,
+        };
+        let result = filter_wifi(&input, &config);
+        assert!(result
+            .sig_matches
+            .get(defaults::SIG_IDX_SSID_PATTERN_START + 0));
+        // Also sets keyword "flock"
+        assert!(result
+            .sig_matches
+            .get(defaults::SIG_IDX_SSID_KEYWORD_START + 0));
+    }
+
+    #[test]
+    fn sig_matches_populated_for_wifi_ssid_exact() {
+        let config = default_config();
+        let input = WiFiScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            ssid: "FS Ext Battery",
+            rssi: -50,
+        };
+        let result = filter_wifi(&input, &config);
+        assert!(result
+            .sig_matches
+            .get(defaults::SIG_IDX_SSID_EXACT_START + 0));
+    }
+
+    #[test]
+    fn sig_matches_populated_for_ble_name() {
+        let config = default_config();
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "Flock Camera",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0,
+            raw_ad: &[],
+        };
+        let result = filter_ble(&input, &config);
+        assert!(result.sig_matches.get(defaults::SIG_IDX_BLE_NAME_START + 0)); // "Flock"
+    }
+
+    #[test]
+    fn sig_matches_populated_for_ble_uuid() {
+        let config = default_config();
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[0x3100], // Raven GPS = index 0
+            manufacturer_id: 0,
+            raw_ad: &[],
+        };
+        let result = filter_ble(&input, &config);
+        assert!(result.sig_matches.get(defaults::SIG_IDX_BLE_UUID_START + 0));
+    }
+
+    #[test]
+    fn sig_matches_populated_for_ble_mfr() {
+        let config = default_config();
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0x09C8, // XUNTONG = index 0
+            raw_ad: &[],
+        };
+        let result = filter_ble(&input, &config);
+        assert!(result.sig_matches.get(defaults::SIG_IDX_BLE_MFR_START + 0));
+    }
+
+    #[test]
+    fn sig_matches_populated_for_ble_ad_bytes() {
+        let config = default_config();
+        let raw_ad = [
+            0x1B, 0xFF, 0x4C, 0x00, 0x12, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0x004C,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble(&input, &config);
+        assert!(result
+            .sig_matches
+            .get(defaults::SIG_IDX_BLE_AD_BYTES_START + 0)); // AirTag
+    }
+
+    // ── Rule integration tests ──────────────────────────────────────
+    //
+    // End-to-end: realistic scan inputs → filter_*_with_rules() → assert rule names
+
+    #[test]
+    fn rule_flock_safety_camera_via_oui() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = WiFiScanInput {
+            mac: &[0xB4, 0x1E, 0x52, 0x01, 0x02, 0x03], // Flock Safety OUI
+            ssid: "SomeNetwork",
+            rssi: -50,
+        };
+        let result = filter_wifi_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Flock Safety Camera"));
+    }
+
+    #[test]
+    fn rule_flock_safety_camera_via_silicon_labs_oui() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = WiFiScanInput {
+            mac: &[0x58, 0x8E, 0x81, 0xAA, 0xBB, 0xCC], // Silicon Labs 58:8E:81
+            ssid: "",
+            rssi: -50,
+        };
+        let result = filter_wifi_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Flock Safety Camera"));
+    }
+
+    #[test]
+    fn rule_flock_safety_camera_via_ssid_pattern() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = WiFiScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            ssid: "Flock-A1B2C3",
+            rssi: -50,
+        };
+        let result = filter_wifi_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Flock Safety Camera"));
+    }
+
+    #[test]
+    fn rule_flock_safety_camera_via_ssid_exact() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = WiFiScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            ssid: "FS Ext Battery",
+            rssi: -50,
+        };
+        let result = filter_wifi_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Flock Safety Camera"));
+    }
+
+    #[test]
+    fn rule_flock_safety_camera_via_ssid_keyword() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = WiFiScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            ssid: "MyFlockThing",
+            rssi: -50,
+        };
+        let result = filter_wifi_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Flock Safety Camera"));
+    }
+
+    #[test]
+    fn rule_flock_safety_camera_via_ble_name() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "Flock Camera",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0,
+            raw_ad: &[],
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Flock Safety Camera"));
+    }
+
+    #[test]
+    fn rule_flock_safety_camera_via_allof_mfr_and_name() {
+        // The nested allOf(xuntong_mfr, flock_ble_name) branch
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "Flock Device",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0x09C8, // XUNTONG
+            raw_ad: &[],
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Flock Safety Camera"));
+    }
+
+    #[test]
+    fn rule_flock_safety_no_match_mfr_only() {
+        // xuntong_mfr alone should NOT trigger Flock Safety Camera rule
+        // (allOf needs both mfr AND ble name)
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "Random Device", // no "Flock" in name
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0x09C8,
+            raw_ad: &[],
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        // It matches on ble_mfr signature, but should NOT trigger the rule
+        assert!(result.matched); // still a signature match
+        assert!(!result.rule_names.contains(&"Flock Safety Camera"));
+    }
+
+    #[test]
+    fn rule_raven_acoustic_sensor_via_gps_uuid() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[0x3100], // Raven GPS service
+            manufacturer_id: 0,
+            raw_ad: &[],
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Raven Acoustic Sensor"));
+    }
+
+    #[test]
+    fn rule_raven_acoustic_sensor_via_error_uuid() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[0x3500], // Raven Error service
+            manufacturer_id: 0,
+            raw_ad: &[],
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Raven Acoustic Sensor"));
+    }
+
+    #[test]
+    fn rule_raven_no_match_wrong_uuid() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[0x180A], // Standard UUID — matches signature but NOT Raven rule
+            manufacturer_id: 0,
+            raw_ad: &[],
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(result.matched); // signature match (std UUID)
+        assert!(!result.rule_names.contains(&"Raven Acoustic Sensor"));
+    }
+
+    #[test]
+    fn rule_apple_airtag_matches() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let raw_ad = [
+            0x1B, 0xFF, 0x4C, 0x00, 0x12, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0x004C,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Apple AirTag"));
+    }
+
+    #[test]
+    fn rule_apple_airtag_no_match_wrong_bytes() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        // Apple manufacturer data but NOT FindMy format
+        let raw_ad = [0x05, 0xFF, 0x4C, 0x00, 0x01, 0x02];
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0x004C,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(!result.rule_names.contains(&"Apple AirTag"));
+    }
+
+    #[test]
+    fn rule_flipper_zero_white_matches() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let raw_ad = [
+            0x02, 0x01, 0x06, // Flags
+            0x05, 0xFF, 0x80, 0x30, 0x01, 0x02,
+        ];
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Flipper Zero"));
+    }
+
+    #[test]
+    fn rule_flipper_zero_black_matches() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let raw_ad = [0x04, 0xFF, 0x81, 0x30, 0x01];
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Flipper Zero"));
+    }
+
+    #[test]
+    fn rule_flipper_zero_no_match_wrong_bytes() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let raw_ad = [0x04, 0xFF, 0x82, 0x30, 0x01]; // 0x82 instead of 0x80/0x81
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "",
+            rssi: -50,
+            service_uuids_16: &[],
+            manufacturer_id: 0,
+            raw_ad: &raw_ad,
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(!result.rule_names.contains(&"Flipper Zero"));
+    }
+
+    #[test]
+    fn rule_no_rules_for_innocent_device() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = BleScanInput {
+            mac: &[0xAA, 0xBB, 0xCC, 0x01, 0x02, 0x03],
+            name: "My Headphones",
+            rssi: -50,
+            service_uuids_16: &[0x180F], // Battery service
+            manufacturer_id: 0,
+            raw_ad: &[],
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(!result.matched);
+        assert!(result.rule_names.is_empty());
+    }
+
+    #[test]
+    fn rule_no_rules_for_wifi_innocent() {
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = WiFiScanInput {
+            mac: &[0xAA, 0xBB, 0xCC, 0x01, 0x02, 0x03],
+            ssid: "Linksys-Home",
+            rssi: -50,
+        };
+        let result = filter_wifi_with_rules(&input, &config, db);
+        assert!(!result.matched);
+        assert!(result.rule_names.is_empty());
+    }
+
+    #[test]
+    fn rule_multiple_rules_can_match_same_event() {
+        // A BLE event that matches both Flock and another rule isn't realistic,
+        // but let's verify the engine returns multiple rule matches.
+        // We need a device with Flock BLE name AND a Raven UUID
+        let config = default_config();
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = BleScanInput {
+            mac: &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            name: "Flock Device",
+            rssi: -50,
+            service_uuids_16: &[0x3100], // Raven GPS
+            manufacturer_id: 0,
+            raw_ad: &[],
+        };
+        let result = filter_ble_with_rules(&input, &config, db);
+        assert!(result.matched);
+        assert!(result.rule_names.contains(&"Flock Safety Camera"));
+        assert!(result.rule_names.contains(&"Raven Acoustic Sensor"));
+        assert_eq!(result.rule_names.len(), 2);
+    }
+
+    #[test]
+    fn rule_disabled_scan_no_rules() {
+        let config = FilterConfig {
+            wifi_enabled: false,
+            ..default_config()
+        };
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = WiFiScanInput {
+            mac: &[0xB4, 0x1E, 0x52, 0x01, 0x02, 0x03],
+            ssid: "Flock-A1B2C3",
+            rssi: -50,
+        };
+        let result = filter_wifi_with_rules(&input, &config, db);
+        assert!(!result.matched);
+        assert!(result.rule_names.is_empty());
+    }
+
+    #[test]
+    fn rule_rssi_below_threshold_no_rules() {
+        let config = FilterConfig {
+            min_rssi: -40,
+            ..default_config()
+        };
+        let db = &defaults::DEFAULT_RULE_DB;
+        let input = WiFiScanInput {
+            mac: &[0xB4, 0x1E, 0x52, 0x01, 0x02, 0x03],
+            ssid: "Flock-A1B2C3",
+            rssi: -50, // below -40 threshold
+        };
+        let result = filter_wifi_with_rules(&input, &config, db);
+        assert!(!result.matched);
+        assert!(result.rule_names.is_empty());
+    }
+
+    // ── Signature index consistency tests ────────────────────────────
+
+    #[test]
+    fn sig_index_ranges_are_contiguous() {
+        // Verify no gaps in the index mapping
+        assert_eq!(defaults::SIG_IDX_MAC_OUI_START, 0);
+        assert_eq!(
+            defaults::SIG_IDX_SSID_PATTERN_START,
+            defaults::SIG_IDX_MAC_OUI_START + defaults::MAC_PREFIXES.len() as u16
+        );
+        assert_eq!(
+            defaults::SIG_IDX_SSID_EXACT_START,
+            defaults::SIG_IDX_SSID_PATTERN_START + defaults::SSID_PATTERNS.len() as u16
+        );
+        assert_eq!(
+            defaults::SIG_IDX_SSID_KEYWORD_START,
+            defaults::SIG_IDX_SSID_EXACT_START + defaults::SSID_EXACT.len() as u16
+        );
+        assert_eq!(
+            defaults::SIG_IDX_WIFI_NAME_START,
+            defaults::SIG_IDX_SSID_KEYWORD_START + defaults::SSID_KEYWORDS.len() as u16
+        );
+        assert_eq!(
+            defaults::SIG_IDX_BLE_NAME_START,
+            defaults::SIG_IDX_WIFI_NAME_START + defaults::WIFI_NAME_KEYWORDS.len() as u16
+        );
+        assert_eq!(
+            defaults::SIG_IDX_BLE_UUID_START,
+            defaults::SIG_IDX_BLE_NAME_START + defaults::BLE_NAME_PATTERNS.len() as u16
+        );
+        assert_eq!(
+            defaults::SIG_IDX_BLE_STD_UUID_START,
+            defaults::SIG_IDX_BLE_UUID_START + defaults::BLE_SERVICE_UUIDS_16.len() as u16
+        );
+        assert_eq!(
+            defaults::SIG_IDX_BLE_MFR_START,
+            defaults::SIG_IDX_BLE_STD_UUID_START + defaults::BLE_STANDARD_UUIDS_16.len() as u16
+        );
+        assert_eq!(
+            defaults::SIG_IDX_BLE_AD_BYTES_START,
+            defaults::SIG_IDX_BLE_MFR_START + defaults::BLE_MANUFACTURER_IDS.len() as u16
+        );
+    }
+
+    #[test]
+    fn sig_count_fits_in_bitset() {
+        assert!(
+            defaults::SIG_COUNT <= crate::rules::MAX_SIGNATURES,
+            "SIG_COUNT {} exceeds MAX_SIGNATURES {}",
+            defaults::SIG_COUNT,
+            crate::rules::MAX_SIGNATURES
+        );
+    }
+
+    #[test]
+    fn default_rule_db_is_valid() {
+        let db = &defaults::DEFAULT_RULE_DB;
+        for rule in db.rules {
+            let end = rule.expr_start as usize + rule.expr_len as usize;
+            assert!(
+                end <= db.nodes.len(),
+                "Rule '{}' references nodes [{}, {}) but pool has {} nodes",
+                rule.name,
+                rule.expr_start,
+                end,
+                db.nodes.len()
+            );
+        }
     }
 
     // ── format_mac tests ────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,4 +21,5 @@ pub mod comm;
 pub mod defaults;
 pub mod filter;
 pub mod protocol;
+pub mod rules;
 pub mod scanner;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -45,6 +45,9 @@ pub enum DeviceMessage<'a> {
         /// Why this result matched the filter
         #[serde(rename = "match")]
         matches: &'a Vec<MatchReason, 4>,
+        /// First matched rule name, if any
+        #[serde(skip_serializing_if = "Option::is_none")]
+        rule: Option<&'a str>,
         /// Uptime in milliseconds when captured
         ts: u32,
     },
@@ -62,6 +65,9 @@ pub enum DeviceMessage<'a> {
         /// Why this result matched the filter
         #[serde(rename = "match")]
         matches: &'a Vec<MatchReason, 4>,
+        /// First matched rule name, if any
+        #[serde(skip_serializing_if = "Option::is_none")]
+        rule: Option<&'a str>,
         /// Uptime in milliseconds when captured
         ts: u32,
     },
@@ -180,6 +186,7 @@ mod tests {
             ch: 6,
             frame: "beacon",
             matches: &matches,
+            rule: None,
             ts: 1000,
         };
 
@@ -207,6 +214,7 @@ mod tests {
             uuid: None,
             mfr: 0x09C8,
             matches: &matches,
+            rule: None,
             ts: 2000,
         };
 
@@ -234,6 +242,7 @@ mod tests {
             uuid: Some(&uuid),
             mfr: 0,
             matches: &matches,
+            rule: None,
             ts: 3000,
         };
 
@@ -241,6 +250,77 @@ mod tests {
         let len = serde_json_core::to_slice(&msg, &mut buf).unwrap();
         let json = core::str::from_utf8(&buf[..len]).unwrap();
         assert!(json.contains(r#""uuid":"00003100-0000-1000-8000-00805f9b34fb""#));
+    }
+
+    // ── Rule field serialization ────────────────────────────────────
+
+    #[test]
+    fn serialize_wifi_scan_with_rule() {
+        let mac = MacString::try_from("B4:1E:52:AB:CD:EF").unwrap();
+        let ssid = NameString::try_from("Flock-A1B2C3").unwrap();
+        let matches = Vec::<MatchReason, 4>::new();
+
+        let msg = DeviceMessage::WiFiScan {
+            mac: &mac,
+            ssid: &ssid,
+            rssi: -45,
+            ch: 6,
+            frame: "beacon",
+            matches: &matches,
+            rule: Some("Flock Safety Camera"),
+            ts: 1000,
+        };
+
+        let mut buf = [0u8; 512];
+        let len = serde_json_core::to_slice(&msg, &mut buf).unwrap();
+        let json = core::str::from_utf8(&buf[..len]).unwrap();
+        assert!(json.contains(r#""rule":"Flock Safety Camera""#));
+    }
+
+    #[test]
+    fn serialize_wifi_scan_without_rule_omits_field() {
+        let mac = MacString::try_from("B4:1E:52:AB:CD:EF").unwrap();
+        let ssid = NameString::try_from("Flock-A1B2C3").unwrap();
+        let matches = Vec::<MatchReason, 4>::new();
+
+        let msg = DeviceMessage::WiFiScan {
+            mac: &mac,
+            ssid: &ssid,
+            rssi: -45,
+            ch: 6,
+            frame: "beacon",
+            matches: &matches,
+            rule: None,
+            ts: 1000,
+        };
+
+        let mut buf = [0u8; 512];
+        let len = serde_json_core::to_slice(&msg, &mut buf).unwrap();
+        let json = core::str::from_utf8(&buf[..len]).unwrap();
+        assert!(!json.contains("rule"));
+    }
+
+    #[test]
+    fn serialize_ble_scan_with_rule() {
+        let mac = MacString::try_from("00:00:00:00:00:00").unwrap();
+        let name = NameString::try_from("").unwrap();
+        let matches = Vec::<MatchReason, 4>::new();
+
+        let msg = DeviceMessage::BleScan {
+            mac: &mac,
+            name: &name,
+            rssi: -50,
+            uuid: None,
+            mfr: 0,
+            matches: &matches,
+            rule: Some("Apple AirTag"),
+            ts: 5000,
+        };
+
+        let mut buf = [0u8; 512];
+        let len = serde_json_core::to_slice(&msg, &mut buf).unwrap();
+        let json = core::str::from_utf8(&buf[..len]).unwrap();
+        assert!(json.contains(r#""rule":"Apple AirTag""#));
     }
 
     // ── Version constant ────────────────────────────────────────────

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,0 +1,1102 @@
+/// Boolean rule composition engine for named device detection.
+///
+/// Rules compose signatures with `anyOf`/`allOf`/`not` boolean logic,
+/// enabling the firmware to report "matched a Flock Safety Camera" rather
+/// than just "matched a Flock Safety MAC OUI."
+///
+/// The expression tree uses a **flat post-order encoding** — children precede
+/// their parent in the array. Evaluated with a fixed-size bool stack.
+/// Zero allocation, `no_std` compatible.
+use heapless::Vec;
+
+/// Index into the signature arrays in `defaults.rs`.
+pub type SigIdx = u16;
+
+/// Maximum number of distinct signatures the bitset can track.
+pub const MAX_SIGNATURES: usize = 256;
+
+/// Maximum depth of the evaluation stack (deepest realistic nesting).
+const MAX_EVAL_STACK: usize = 16;
+
+/// A node in a post-order expression tree.
+///
+/// Expressions are stored as flat arrays where children always precede
+/// their parent. For example, `anyOf(sig0, allOf(sig1, sig2))` encodes as:
+/// `[Sig(0), Sig(1), Sig(2), AllOf{count:2}, AnyOf{count:2}]`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExprNode {
+    /// Leaf: true if the signature at this index was matched.
+    Sig(SigIdx),
+    /// OR over the preceding `count` results on the stack.
+    AnyOf { count: u8 },
+    /// AND over the preceding `count` results on the stack.
+    AllOf { count: u8 },
+    /// Invert the preceding result on the stack.
+    Not,
+}
+
+/// A 256-bit bitset tracking which signatures matched in a scan event.
+///
+/// Each bit position corresponds to a `SigIdx`. Constant-time set/get.
+/// Stack-only — 32 bytes.
+#[derive(Debug, Clone)]
+pub struct SigMatchSet {
+    bits: [u64; 4],
+}
+
+impl SigMatchSet {
+    /// Create an empty match set (no signatures matched).
+    pub const fn new() -> Self {
+        Self { bits: [0; 4] }
+    }
+
+    /// Mark a signature index as matched.
+    ///
+    /// Indices >= MAX_SIGNATURES are silently ignored.
+    #[inline]
+    pub fn set(&mut self, idx: SigIdx) {
+        let i = idx as usize;
+        if i < MAX_SIGNATURES {
+            self.bits[i / 64] |= 1u64 << (i % 64);
+        }
+    }
+
+    /// Check if a signature index is marked as matched.
+    #[inline]
+    pub fn get(&self, idx: SigIdx) -> bool {
+        let i = idx as usize;
+        if i < MAX_SIGNATURES {
+            (self.bits[i / 64] >> (i % 64)) & 1 == 1
+        } else {
+            false
+        }
+    }
+
+    /// Returns true if no signatures are matched.
+    pub fn is_empty(&self) -> bool {
+        self.bits.iter().all(|&w| w == 0)
+    }
+}
+
+/// A named rule that references a slice of the shared expression node pool.
+#[derive(Debug, Clone, Copy)]
+pub struct Rule {
+    /// Human-readable rule name (e.g., "Flock Safety Camera").
+    pub name: &'static str,
+    /// Starting offset into the shared `RuleDb::nodes` array.
+    pub expr_start: u16,
+    /// Number of expression nodes for this rule.
+    pub expr_len: u16,
+}
+
+/// A compiled rule database: a shared pool of expression nodes and
+/// an array of rules that reference slices of the pool.
+#[derive(Debug, Clone, Copy)]
+pub struct RuleDb {
+    /// Shared pool of expression nodes (all rules' nodes concatenated).
+    pub nodes: &'static [ExprNode],
+    /// Array of rule definitions referencing slices of `nodes`.
+    pub rules: &'static [Rule],
+}
+
+/// Evaluate a single expression (a slice of post-order `ExprNode`s)
+/// against the matched signature set.
+///
+/// Returns `true` if the expression evaluates to true.
+/// Returns `false` for empty expressions or on stack overflow.
+pub fn evaluate_rule(nodes: &[ExprNode], matched: &SigMatchSet) -> bool {
+    if nodes.is_empty() {
+        return false;
+    }
+
+    let mut stack: Vec<bool, MAX_EVAL_STACK> = Vec::new();
+
+    for &node in nodes {
+        match node {
+            ExprNode::Sig(idx) => {
+                if stack.push(matched.get(idx)).is_err() {
+                    return false; // stack overflow
+                }
+            }
+            ExprNode::AnyOf { count } => {
+                let count = count as usize;
+                if stack.len() < count {
+                    return false; // underflow
+                }
+                let start = stack.len() - count;
+                let result = stack[start..].iter().any(|&v| v);
+                stack.truncate(start);
+                if stack.push(result).is_err() {
+                    return false;
+                }
+            }
+            ExprNode::AllOf { count } => {
+                let count = count as usize;
+                if stack.len() < count {
+                    return false; // underflow
+                }
+                let start = stack.len() - count;
+                let result = stack[start..].iter().all(|&v| v);
+                stack.truncate(start);
+                if stack.push(result).is_err() {
+                    return false;
+                }
+            }
+            ExprNode::Not => {
+                if let Some(val) = stack.pop() {
+                    if stack.push(!val).is_err() {
+                        return false;
+                    }
+                } else {
+                    return false; // underflow
+                }
+            }
+        }
+    }
+
+    // The final result should be exactly one value on the stack
+    stack.len() == 1 && stack[0]
+}
+
+/// Evaluate all rules in a database against the matched signature set.
+///
+/// Returns indices (into `db.rules`) of rules that matched, up to 4.
+pub fn evaluate_rules(db: &RuleDb, matched: &SigMatchSet) -> Vec<u16, 4> {
+    let mut result = Vec::new();
+
+    for (i, rule) in db.rules.iter().enumerate() {
+        let start = rule.expr_start as usize;
+        let end = start + rule.expr_len as usize;
+
+        if end <= db.nodes.len() {
+            let nodes = &db.nodes[start..end];
+            if evaluate_rule(nodes, matched) {
+                let _ = result.push(i as u16);
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── SigMatchSet tests ───────────────────────────────────────────
+
+    #[test]
+    fn sigmatchset_empty_on_creation() {
+        let set = SigMatchSet::new();
+        assert!(set.is_empty());
+        for i in 0..256u16 {
+            assert!(!set.get(i), "bit {i} should be unset");
+        }
+    }
+
+    #[test]
+    fn sigmatchset_set_and_get_bit_zero() {
+        let mut set = SigMatchSet::new();
+        set.set(0);
+        assert!(set.get(0));
+        assert!(!set.is_empty());
+    }
+
+    #[test]
+    fn sigmatchset_set_and_get_bit_63() {
+        let mut set = SigMatchSet::new();
+        set.set(63);
+        assert!(set.get(63));
+        assert!(!set.get(62));
+        assert!(!set.get(64));
+    }
+
+    #[test]
+    fn sigmatchset_set_and_get_bit_64() {
+        let mut set = SigMatchSet::new();
+        set.set(64);
+        assert!(set.get(64));
+        assert!(!set.get(63));
+        assert!(!set.get(65));
+    }
+
+    #[test]
+    fn sigmatchset_set_and_get_bit_127() {
+        let mut set = SigMatchSet::new();
+        set.set(127);
+        assert!(set.get(127));
+        assert!(!set.get(126));
+        assert!(!set.get(128));
+    }
+
+    #[test]
+    fn sigmatchset_set_and_get_bit_128() {
+        let mut set = SigMatchSet::new();
+        set.set(128);
+        assert!(set.get(128));
+    }
+
+    #[test]
+    fn sigmatchset_set_and_get_bit_255() {
+        let mut set = SigMatchSet::new();
+        set.set(255);
+        assert!(set.get(255));
+        assert!(!set.get(254));
+    }
+
+    #[test]
+    fn sigmatchset_out_of_range_ignored() {
+        let mut set = SigMatchSet::new();
+        set.set(256); // should be silently ignored
+        set.set(1000);
+        assert!(set.is_empty());
+        assert!(!set.get(256));
+        assert!(!set.get(1000));
+    }
+
+    #[test]
+    fn sigmatchset_multiple_bits_set() {
+        let mut set = SigMatchSet::new();
+        set.set(0);
+        set.set(42);
+        set.set(100);
+        set.set(200);
+        set.set(255);
+        assert!(set.get(0));
+        assert!(set.get(42));
+        assert!(set.get(100));
+        assert!(set.get(200));
+        assert!(set.get(255));
+        // Spot-check unset values
+        assert!(!set.get(1));
+        assert!(!set.get(41));
+        assert!(!set.get(99));
+        assert!(!set.get(201));
+        assert!(!set.get(254));
+    }
+
+    #[test]
+    fn sigmatchset_set_idempotent() {
+        let mut set = SigMatchSet::new();
+        set.set(10);
+        set.set(10);
+        set.set(10);
+        assert!(set.get(10));
+    }
+
+    #[test]
+    fn sigmatchset_all_word_boundaries() {
+        let mut set = SigMatchSet::new();
+        // Set bits at each u64 boundary
+        for &idx in &[0u16, 63, 64, 127, 128, 191, 192, 255] {
+            set.set(idx);
+        }
+        for &idx in &[0u16, 63, 64, 127, 128, 191, 192, 255] {
+            assert!(set.get(idx), "bit {idx} should be set");
+        }
+        // Check that adjacent bits are NOT set
+        for &idx in &[1u16, 62, 65, 126, 129, 190, 193, 254] {
+            assert!(!set.get(idx), "bit {idx} should NOT be set");
+        }
+    }
+
+    // ── evaluate_rule: single Sig leaf ──────────────────────────────
+
+    #[test]
+    fn eval_single_sig_match() {
+        let mut matched = SigMatchSet::new();
+        matched.set(5);
+        let nodes = [ExprNode::Sig(5)];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_single_sig_no_match() {
+        let matched = SigMatchSet::new();
+        let nodes = [ExprNode::Sig(5)];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_single_sig_wrong_index() {
+        let mut matched = SigMatchSet::new();
+        matched.set(3);
+        let nodes = [ExprNode::Sig(5)];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    // ── evaluate_rule: AnyOf ────────────────────────────────────────
+
+    #[test]
+    fn eval_anyof_first_matches() {
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Sig(2),
+            ExprNode::AnyOf { count: 3 },
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_anyof_last_matches() {
+        let mut matched = SigMatchSet::new();
+        matched.set(2);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Sig(2),
+            ExprNode::AnyOf { count: 3 },
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_anyof_all_match() {
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        matched.set(1);
+        matched.set(2);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Sig(2),
+            ExprNode::AnyOf { count: 3 },
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_anyof_none_match() {
+        let matched = SigMatchSet::new();
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Sig(2),
+            ExprNode::AnyOf { count: 3 },
+        ];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_anyof_single_child() {
+        let mut matched = SigMatchSet::new();
+        matched.set(7);
+        let nodes = [ExprNode::Sig(7), ExprNode::AnyOf { count: 1 }];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    // ── evaluate_rule: AllOf ────────────────────────────────────────
+
+    #[test]
+    fn eval_allof_all_match() {
+        let mut matched = SigMatchSet::new();
+        matched.set(10);
+        matched.set(11);
+        matched.set(12);
+        let nodes = [
+            ExprNode::Sig(10),
+            ExprNode::Sig(11),
+            ExprNode::Sig(12),
+            ExprNode::AllOf { count: 3 },
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_allof_one_missing() {
+        let mut matched = SigMatchSet::new();
+        matched.set(10);
+        matched.set(12);
+        // sig 11 not matched
+        let nodes = [
+            ExprNode::Sig(10),
+            ExprNode::Sig(11),
+            ExprNode::Sig(12),
+            ExprNode::AllOf { count: 3 },
+        ];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_allof_none_match() {
+        let matched = SigMatchSet::new();
+        let nodes = [
+            ExprNode::Sig(10),
+            ExprNode::Sig(11),
+            ExprNode::AllOf { count: 2 },
+        ];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_allof_single_child_match() {
+        let mut matched = SigMatchSet::new();
+        matched.set(5);
+        let nodes = [ExprNode::Sig(5), ExprNode::AllOf { count: 1 }];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_allof_single_child_no_match() {
+        let matched = SigMatchSet::new();
+        let nodes = [ExprNode::Sig(5), ExprNode::AllOf { count: 1 }];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    // ── evaluate_rule: Not ──────────────────────────────────────────
+
+    #[test]
+    fn eval_not_inverts_true_to_false() {
+        let mut matched = SigMatchSet::new();
+        matched.set(3);
+        let nodes = [ExprNode::Sig(3), ExprNode::Not];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_not_inverts_false_to_true() {
+        let matched = SigMatchSet::new();
+        let nodes = [ExprNode::Sig(3), ExprNode::Not];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_double_not_identity() {
+        let mut matched = SigMatchSet::new();
+        matched.set(3);
+        let nodes = [ExprNode::Sig(3), ExprNode::Not, ExprNode::Not];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_not_of_anyof() {
+        // not(anyOf(sig0, sig1)) — neither matched, so anyOf=false, not=true
+        let matched = SigMatchSet::new();
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::AnyOf { count: 2 },
+            ExprNode::Not,
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_not_of_anyof_when_one_matches() {
+        // not(anyOf(sig0, sig1)) — sig0 matched, so anyOf=true, not=false
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::AnyOf { count: 2 },
+            ExprNode::Not,
+        ];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    // ── evaluate_rule: nested compositions ──────────────────────────
+
+    #[test]
+    fn eval_anyof_with_nested_allof() {
+        // anyOf(sig0, allOf(sig1, sig2))
+        // Encoding: [Sig(0), Sig(1), Sig(2), AllOf{2}, AnyOf{2}]
+        //
+        // Case: only sig1+sig2 match → allOf=true → anyOf=true
+        let mut matched = SigMatchSet::new();
+        matched.set(1);
+        matched.set(2);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Sig(2),
+            ExprNode::AllOf { count: 2 },
+            ExprNode::AnyOf { count: 2 },
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_anyof_with_nested_allof_only_first() {
+        // anyOf(sig0, allOf(sig1, sig2))
+        // Case: only sig0 matches → anyOf=true via sig0
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Sig(2),
+            ExprNode::AllOf { count: 2 },
+            ExprNode::AnyOf { count: 2 },
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_anyof_with_nested_allof_partial() {
+        // anyOf(sig0, allOf(sig1, sig2))
+        // Case: only sig1 matches → allOf=false, sig0=false → anyOf=false
+        let mut matched = SigMatchSet::new();
+        matched.set(1);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Sig(2),
+            ExprNode::AllOf { count: 2 },
+            ExprNode::AnyOf { count: 2 },
+        ];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_allof_with_nested_anyof() {
+        // allOf(anyOf(sig0, sig1), sig2)
+        // Encoding: [Sig(0), Sig(1), AnyOf{2}, Sig(2), AllOf{2}]
+        let mut matched = SigMatchSet::new();
+        matched.set(1);
+        matched.set(2);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::AnyOf { count: 2 },
+            ExprNode::Sig(2),
+            ExprNode::AllOf { count: 2 },
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_allof_with_nested_anyof_missing_required() {
+        // allOf(anyOf(sig0, sig1), sig2)
+        // sig0 matches but sig2 doesn't → allOf=false
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::AnyOf { count: 2 },
+            ExprNode::Sig(2),
+            ExprNode::AllOf { count: 2 },
+        ];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_allof_with_not_child() {
+        // allOf(sig0, not(sig1)) — sig0 present, sig1 absent → true
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Not,
+            ExprNode::AllOf { count: 2 },
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_allof_with_not_child_fails() {
+        // allOf(sig0, not(sig1)) — sig0 present, sig1 also present → false
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        matched.set(1);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Not,
+            ExprNode::AllOf { count: 2 },
+        ];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_deeply_nested() {
+        // anyOf(allOf(sig0, not(sig1)), allOf(sig2, sig3))
+        // Encoding:
+        //   [Sig(0), Sig(1), Not, AllOf{2}, Sig(2), Sig(3), AllOf{2}, AnyOf{2}]
+        //
+        // Case: sig0=true, sig1=false → allOf(true, not(false)=true) = true → anyOf=true
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Not,
+            ExprNode::AllOf { count: 2 },
+            ExprNode::Sig(2),
+            ExprNode::Sig(3),
+            ExprNode::AllOf { count: 2 },
+            ExprNode::AnyOf { count: 2 },
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_deeply_nested_second_branch() {
+        // Same tree, but this time sig2+sig3 match instead
+        let mut matched = SigMatchSet::new();
+        matched.set(2);
+        matched.set(3);
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Not,
+            ExprNode::AllOf { count: 2 },
+            ExprNode::Sig(2),
+            ExprNode::Sig(3),
+            ExprNode::AllOf { count: 2 },
+            ExprNode::AnyOf { count: 2 },
+        ];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_deeply_nested_neither_branch() {
+        // Same tree, but sig1=true blocks first branch, sig3 missing blocks second
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        matched.set(1); // blocks not(sig1)
+        matched.set(2); // sig3 missing
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Not,
+            ExprNode::AllOf { count: 2 },
+            ExprNode::Sig(2),
+            ExprNode::Sig(3),
+            ExprNode::AllOf { count: 2 },
+            ExprNode::AnyOf { count: 2 },
+        ];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    // ── evaluate_rule: edge cases ───────────────────────────────────
+
+    #[test]
+    fn eval_empty_expression_returns_false() {
+        let matched = SigMatchSet::new();
+        assert!(!evaluate_rule(&[], &matched));
+    }
+
+    #[test]
+    fn eval_anyof_count_zero_leaves_stack_unchanged() {
+        // AnyOf{count:0} with no prior stack items → should push false (vacuous OR)
+        // But our stack has nothing, count=0 means start==stack.len(), result = .any() on empty = false
+        let matched = SigMatchSet::new();
+        let nodes = [ExprNode::AnyOf { count: 0 }];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_allof_count_zero_produces_true() {
+        // AllOf{count:0} — vacuous truth
+        let matched = SigMatchSet::new();
+        let nodes = [ExprNode::AllOf { count: 0 }];
+        assert!(evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_stack_underflow_not_returns_false() {
+        // Not with empty stack — should return false (underflow guard)
+        let matched = SigMatchSet::new();
+        let nodes = [ExprNode::Not];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_stack_underflow_anyof_returns_false() {
+        // AnyOf{count:3} with only 1 item on stack
+        let matched = SigMatchSet::new();
+        let nodes = [ExprNode::Sig(0), ExprNode::AnyOf { count: 3 }];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    #[test]
+    fn eval_multiple_values_on_stack_returns_false() {
+        // Two Sig leaves with no combining operator — stack has 2 items, not 1
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        matched.set(1);
+        let nodes = [ExprNode::Sig(0), ExprNode::Sig(1)];
+        assert!(!evaluate_rule(&nodes, &matched));
+    }
+
+    // ── evaluate_rule: real-world rule patterns ─────────────────────
+
+    #[test]
+    fn eval_flock_safety_pattern() {
+        // Simulates: anyOf(sig0..sig7, allOf(sig8, sig6))
+        // This is the Flock Safety Camera rule shape from the schema example
+        let nodes = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::Sig(2),
+            ExprNode::Sig(3),
+            ExprNode::Sig(4),
+            ExprNode::Sig(5),
+            ExprNode::Sig(6),
+            ExprNode::Sig(7),
+            ExprNode::Sig(8),
+            ExprNode::Sig(6), // sig6 referenced again
+            ExprNode::AllOf { count: 2 },
+            ExprNode::AnyOf { count: 9 },
+        ];
+
+        // Case 1: only sig0 matched → true (anyOf via sig0)
+        let mut m = SigMatchSet::new();
+        m.set(0);
+        assert!(evaluate_rule(&nodes, &m));
+
+        // Case 2: only sig8+sig6 → true (via allOf)
+        let mut m = SigMatchSet::new();
+        m.set(8);
+        m.set(6);
+        assert!(evaluate_rule(&nodes, &m));
+
+        // Case 3: only sig8 → false (allOf needs sig6 too, and sig8 alone isn't in the flat anyOf)
+        let mut m = SigMatchSet::new();
+        m.set(8);
+        assert!(!evaluate_rule(&nodes, &m));
+
+        // Case 4: none matched → false
+        let m = SigMatchSet::new();
+        assert!(!evaluate_rule(&nodes, &m));
+    }
+
+    #[test]
+    fn eval_simple_anyof_like_raven() {
+        // Raven: anyOf(uuid0, uuid1, uuid2, uuid3, uuid4)
+        let nodes = [
+            ExprNode::Sig(20),
+            ExprNode::Sig(21),
+            ExprNode::Sig(22),
+            ExprNode::Sig(23),
+            ExprNode::Sig(24),
+            ExprNode::AnyOf { count: 5 },
+        ];
+
+        let mut m = SigMatchSet::new();
+        m.set(22);
+        assert!(evaluate_rule(&nodes, &m));
+
+        let m = SigMatchSet::new();
+        assert!(!evaluate_rule(&nodes, &m));
+    }
+
+    #[test]
+    fn eval_single_sig_like_airtag() {
+        // AirTag: just one sig reference
+        let nodes = [ExprNode::Sig(100)];
+
+        let mut m = SigMatchSet::new();
+        m.set(100);
+        assert!(evaluate_rule(&nodes, &m));
+
+        let m = SigMatchSet::new();
+        assert!(!evaluate_rule(&nodes, &m));
+    }
+
+    #[test]
+    fn eval_two_branch_anyof_like_flipper() {
+        // Flipper Zero: anyOf(white, black)
+        let nodes = [
+            ExprNode::Sig(50),
+            ExprNode::Sig(51),
+            ExprNode::AnyOf { count: 2 },
+        ];
+
+        let mut m = SigMatchSet::new();
+        m.set(50);
+        assert!(evaluate_rule(&nodes, &m));
+
+        let mut m = SigMatchSet::new();
+        m.set(51);
+        assert!(evaluate_rule(&nodes, &m));
+
+        let m = SigMatchSet::new();
+        assert!(!evaluate_rule(&nodes, &m));
+    }
+
+    // ── evaluate_rules (multi-rule) ─────────────────────────────────
+
+    #[test]
+    fn evaluate_rules_no_match() {
+        static NODES: &[ExprNode] = &[
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::AnyOf { count: 2 },
+        ];
+        static RULES: &[Rule] = &[Rule {
+            name: "Rule A",
+            expr_start: 0,
+            expr_len: 3,
+        }];
+        let db = RuleDb {
+            nodes: NODES,
+            rules: RULES,
+        };
+
+        let matched = SigMatchSet::new();
+        let result = evaluate_rules(&db, &matched);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn evaluate_rules_one_of_two_matches() {
+        // Rule A: anyOf(sig0, sig1)
+        // Rule B: sig2
+        static NODES: &[ExprNode] = &[
+            // Rule A: indices 0..3
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::AnyOf { count: 2 },
+            // Rule B: index 3
+            ExprNode::Sig(2),
+        ];
+        static RULES: &[Rule] = &[
+            Rule {
+                name: "Rule A",
+                expr_start: 0,
+                expr_len: 3,
+            },
+            Rule {
+                name: "Rule B",
+                expr_start: 3,
+                expr_len: 1,
+            },
+        ];
+        let db = RuleDb {
+            nodes: NODES,
+            rules: RULES,
+        };
+
+        // Only sig0 matched → Rule A fires, Rule B doesn't
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        let result = evaluate_rules(&db, &matched);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], 0); // Rule A index
+        assert_eq!(db.rules[result[0] as usize].name, "Rule A");
+    }
+
+    #[test]
+    fn evaluate_rules_both_match() {
+        static NODES: &[ExprNode] = &[
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::AnyOf { count: 2 },
+            ExprNode::Sig(2),
+        ];
+        static RULES: &[Rule] = &[
+            Rule {
+                name: "Rule A",
+                expr_start: 0,
+                expr_len: 3,
+            },
+            Rule {
+                name: "Rule B",
+                expr_start: 3,
+                expr_len: 1,
+            },
+        ];
+        let db = RuleDb {
+            nodes: NODES,
+            rules: RULES,
+        };
+
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        matched.set(2);
+        let result = evaluate_rules(&db, &matched);
+        assert_eq!(result.len(), 2);
+        assert_eq!(db.rules[result[0] as usize].name, "Rule A");
+        assert_eq!(db.rules[result[1] as usize].name, "Rule B");
+    }
+
+    #[test]
+    fn evaluate_rules_max_four_returned() {
+        // 5 rules, all match — only first 4 returned
+        static NODES: &[ExprNode] = &[
+            ExprNode::Sig(0),
+            ExprNode::Sig(0),
+            ExprNode::Sig(0),
+            ExprNode::Sig(0),
+            ExprNode::Sig(0),
+        ];
+        static RULES: &[Rule] = &[
+            Rule {
+                name: "R0",
+                expr_start: 0,
+                expr_len: 1,
+            },
+            Rule {
+                name: "R1",
+                expr_start: 1,
+                expr_len: 1,
+            },
+            Rule {
+                name: "R2",
+                expr_start: 2,
+                expr_len: 1,
+            },
+            Rule {
+                name: "R3",
+                expr_start: 3,
+                expr_len: 1,
+            },
+            Rule {
+                name: "R4",
+                expr_start: 4,
+                expr_len: 1,
+            },
+        ];
+        let db = RuleDb {
+            nodes: NODES,
+            rules: RULES,
+        };
+
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        let result = evaluate_rules(&db, &matched);
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn evaluate_rules_invalid_range_skipped() {
+        // Rule with expr_start+expr_len beyond nodes — should be skipped
+        static NODES: &[ExprNode] = &[ExprNode::Sig(0)];
+        static RULES: &[Rule] = &[Rule {
+            name: "Bad rule",
+            expr_start: 0,
+            expr_len: 10, // way beyond nodes length
+        }];
+        let db = RuleDb {
+            nodes: NODES,
+            rules: RULES,
+        };
+
+        let mut matched = SigMatchSet::new();
+        matched.set(0);
+        let result = evaluate_rules(&db, &matched);
+        assert!(result.is_empty());
+    }
+
+    // ── Stress / property-like tests ────────────────────────────────
+
+    #[test]
+    fn eval_anyof_is_commutative() {
+        // anyOf(sig0, sig1) should equal anyOf(sig1, sig0) for any input
+        let orders = [
+            [
+                ExprNode::Sig(0),
+                ExprNode::Sig(1),
+                ExprNode::AnyOf { count: 2 },
+            ],
+            [
+                ExprNode::Sig(1),
+                ExprNode::Sig(0),
+                ExprNode::AnyOf { count: 2 },
+            ],
+        ];
+
+        for sig_to_set in [None, Some(0u16), Some(1), Some(99)] {
+            let mut m = SigMatchSet::new();
+            if let Some(s) = sig_to_set {
+                m.set(s);
+            }
+            let r0 = evaluate_rule(&orders[0], &m);
+            let r1 = evaluate_rule(&orders[1], &m);
+            assert_eq!(r0, r1, "AnyOf should be commutative for sig={sig_to_set:?}");
+        }
+    }
+
+    #[test]
+    fn eval_allof_is_commutative() {
+        let orders = [
+            [
+                ExprNode::Sig(0),
+                ExprNode::Sig(1),
+                ExprNode::AllOf { count: 2 },
+            ],
+            [
+                ExprNode::Sig(1),
+                ExprNode::Sig(0),
+                ExprNode::AllOf { count: 2 },
+            ],
+        ];
+
+        for sigs in [vec![], vec![0], vec![1], vec![0, 1]] {
+            let mut m = SigMatchSet::new();
+            for s in &sigs {
+                m.set(*s);
+            }
+            let r0 = evaluate_rule(&orders[0], &m);
+            let r1 = evaluate_rule(&orders[1], &m);
+            assert_eq!(r0, r1, "AllOf should be commutative for sigs={sigs:?}");
+        }
+    }
+
+    #[test]
+    fn eval_de_morgans_law_not_anyof() {
+        // De Morgan's: not(anyOf(a, b)) == allOf(not(a), not(b))
+        let lhs = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::AnyOf { count: 2 },
+            ExprNode::Not,
+        ];
+        let rhs = [
+            ExprNode::Sig(0),
+            ExprNode::Not,
+            ExprNode::Sig(1),
+            ExprNode::Not,
+            ExprNode::AllOf { count: 2 },
+        ];
+
+        for sigs in [vec![], vec![0], vec![1], vec![0, 1]] {
+            let mut m = SigMatchSet::new();
+            for s in &sigs {
+                m.set(*s);
+            }
+            assert_eq!(
+                evaluate_rule(&lhs, &m),
+                evaluate_rule(&rhs, &m),
+                "De Morgan's law violated for sigs={sigs:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn eval_de_morgans_law_not_allof() {
+        // De Morgan's: not(allOf(a, b)) == anyOf(not(a), not(b))
+        let lhs = [
+            ExprNode::Sig(0),
+            ExprNode::Sig(1),
+            ExprNode::AllOf { count: 2 },
+            ExprNode::Not,
+        ];
+        let rhs = [
+            ExprNode::Sig(0),
+            ExprNode::Not,
+            ExprNode::Sig(1),
+            ExprNode::Not,
+            ExprNode::AnyOf { count: 2 },
+        ];
+
+        for sigs in [vec![], vec![0], vec![1], vec![0, 1]] {
+            let mut m = SigMatchSet::new();
+            for s in &sigs {
+                m.set(*s);
+            }
+            assert_eq!(
+                evaluate_rule(&lhs, &m),
+                evaluate_rule(&rhs, &m),
+                "De Morgan's law violated for sigs={sigs:?}"
+            );
+        }
+    }
+}

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -61,6 +61,8 @@ pub struct BleEvent {
     pub service_uuids_16: Vec<u16, 8>,
     /// Manufacturer company ID (0 if not present)
     pub manufacturer_id: u16,
+    /// Raw advertisement data bytes (up to 62 bytes: AD + scan response)
+    pub raw_ad: Vec<u8, 62>,
 }
 
 /// Unified scan event for the filter task
@@ -158,12 +160,18 @@ impl BleAdvParser {
     /// `rssi` is the received signal strength.
     /// `ad_data` is the raw advertisement data bytes.
     pub fn parse(addr: &[u8; 6], rssi: i8, ad_data: &[u8]) -> BleEvent {
+        let mut raw_ad = Vec::new();
+        for &b in ad_data.iter().take(62) {
+            let _ = raw_ad.push(b);
+        }
+
         let mut event = BleEvent {
             mac: *addr,
             name: heapless::String::new(),
             rssi,
             service_uuids_16: Vec::new(),
             manufacturer_id: 0,
+            raw_ad,
         };
 
         let mut pos = 0;


### PR DESCRIPTION
## Summary

- Add zero-allocation rule evaluation engine (`src/rules.rs`) that composes signatures with `anyOf`/`allOf`/`not` boolean logic using post-order flat array encoding — enables named device detection
- Add `ble_ad_bytes` signature type support with fixed-offset and anywhere matching modes
- Add signature index tracking (`SigMatchSet`, 256-bit bitset) across all 7 signature types
- Compile in 4 rules from the schema examples: Flock Safety Camera, Raven Acoustic Sensor, Apple AirTag, Flipper Zero
- Add `filter_wifi_with_rules()` / `filter_ble_with_rules()` integration wrappers
- Add `rule` field to `DeviceMessage` WiFiScan/BleScan variants (omitted when `None`)
- 165+ tests including end-to-end rule evaluation for all 4 rules

Memory impact: ~1.4KB total (no heap, no `alloc`).

Closes #37

## Test plan

- [ ] `just docker-test` — all 165+ unit tests pass
- [ ] `just docker-build` — both ESP32 targets compile
- [ ] Verify rule names appear in scan output for matching devices
- [ ] Verify `rule` field omitted from JSON when no rule matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)