### PR TITLE
ci: bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
       - run: pip install check-jsonschema
@@ -102,7 +102,7 @@ jobs:
           . /home/esp/export-esp.sh
           cargo build --no-default-features --features ${{ matrix.features }} --release --target ${{ matrix.target }} -Z build-std=core,alloc
 
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: elf-${{ matrix.name }}
           path: target/${{ matrix.target }}/release/airhound
@@ -136,7 +136,7 @@ jobs:
           . /home/esp/export-esp.sh
           cd firmware-std && MCU=${{ matrix.chip }} cargo build --no-default-features --features ${{ matrix.features }} --release --target ${{ matrix.target }} -Z build-std=std,panic_abort
 
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: elf-${{ matrix.name }}
           path: firmware-std/target/${{ matrix.target }}/release/airhound-std
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - if: env.WOKWI_CLI_TOKEN != ''
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         with:
           name: elf-m5stickc
           path: target/xtensa-esp32-none-elf/release/
@@ -183,14 +183,14 @@ jobs:
       - name: Install espflash
         run: cargo binstall espflash --no-confirm
 
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         with:
           name: elf-${{ matrix.name }}
 
       - name: Create flashable binary
         run: espflash save-image --chip ${{ matrix.chip }} airhound airhound-${{ matrix.name }}.bin
 
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: bin-${{ matrix.name }}
           path: airhound-${{ matrix.name }}.bin
@@ -213,14 +213,14 @@ jobs:
       - name: Install espflash
         run: cargo binstall espflash --no-confirm
 
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         with:
           name: elf-${{ matrix.name }}
 
       - name: Create flashable binary
         run: espflash save-image --chip ${{ matrix.chip }} airhound-std airhound-${{ matrix.name }}.bin
 
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: bin-${{ matrix.name }}
           path: airhound-${{ matrix.name }}.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           . /home/esp/export-esp.sh
           espflash save-image --chip ${{ matrix.chip }} target/${{ matrix.target }}/release/airhound airhound-${{ matrix.name }}.bin
 
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: release-bin-${{ matrix.name }}
           path: airhound-${{ matrix.name }}.bin
@@ -68,7 +68,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         with:
           pattern: release-bin-*
           merge-multiple: true


### PR DESCRIPTION
## Summary

- `actions/setup-python` v5 → v6
- `actions/upload-artifact` v6 → v7
- `actions/download-artifact` v7 → v8
- `extractions/setup-just` v3 pin update

Consolidates Dependabot PRs #62, #63, #64, #65.

## Test plan

- [ ] CI passes with updated action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)