### PR TITLE
refactor: remove vendor field from OuiValue to save DRAM

### DIFF
--- a/src/comm.rs
+++ b/src/comm.rs
@@ -170,28 +170,15 @@ pub fn handle_command(
             None
         }
         HostCommand::AddProximityTarget { mac, label } => {
-            log::info!(
-                "Add proximity target: {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} label={}",
-                mac[0],
-                mac[1],
-                mac[2],
-                mac[3],
-                mac[4],
-                mac[5],
-                label.as_str()
-            );
+            let mut mac_str = crate::protocol::MacString::new();
+            crate::protocol::format_mac(mac, &mut mac_str);
+            log::info!("Add proximity target: {} label={}", mac_str, label.as_str());
             None
         }
         HostCommand::RemoveProximityTarget { mac } => {
-            log::info!(
-                "Remove proximity target: {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
-                mac[0],
-                mac[1],
-                mac[2],
-                mac[3],
-                mac[4],
-                mac[5]
-            );
+            let mut mac_str = crate::protocol::MacString::new();
+            crate::protocol::format_mac(mac, &mut mac_str);
+            log::info!("Remove proximity target: {}", mac_str);
             None
         }
         HostCommand::ClearProximityTargets => {
@@ -204,10 +191,14 @@ pub fn handle_command(
             full_mac,
             label,
         } => {
+            let mut mac_str = crate::protocol::MacString::new();
+            crate::protocol::format_mac(mac, &mut mac_str);
             log::info!(
-                "Add watchlist: id={} mac={:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} full={} label={}",
-                id, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
-                full_mac, label.as_str()
+                "Add watchlist: id={} mac={} full={} label={}",
+                id,
+                mac_str,
+                full_mac,
+                label.as_str()
             );
             None
         }

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -251,6 +251,17 @@ pub static BLE_AD_BYTES_PATTERNS: &[BleAdBytesPattern] = &[
 use crate::rules::{ExprNode, MatchCategory, Rule, RuleDb, SigIdx};
 
 pub const SIG_IDX_MAC_OUI_START: SigIdx = 0;
+
+/// Look up the vendor name for a MAC OUI signature index.
+/// Returns empty string if the index is out of range or not a MAC OUI signature.
+pub fn vendor_for_sig_idx(sig_idx: u16) -> &'static str {
+    let offset = sig_idx.wrapping_sub(SIG_IDX_MAC_OUI_START) as usize;
+    if offset < MAC_PREFIXES.len() {
+        MAC_PREFIXES[offset].1
+    } else {
+        ""
+    }
+}
 pub const SIG_IDX_SSID_PATTERN_START: SigIdx = MAC_PREFIXES.len() as SigIdx;
 pub const SIG_IDX_SSID_EXACT_START: SigIdx =
     SIG_IDX_SSID_PATTERN_START + SSID_PATTERNS.len() as SigIdx;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -148,32 +148,34 @@ pub fn filter_wifi(
     }
 
     // SSID keyword substring check (case-insensitive)
-    let ssid_lower: Vec<u8, 33> = input
-        .ssid
-        .bytes()
-        .take(33)
-        .map(|b| b.to_ascii_lowercase())
-        .collect();
-    let ssid_lower_str = core::str::from_utf8(&ssid_lower).unwrap_or("");
+    if !input.ssid.is_empty() {
+        let ssid_lower: Vec<u8, 33> = input
+            .ssid
+            .bytes()
+            .take(33)
+            .map(|b| b.to_ascii_lowercase())
+            .collect();
+        let ssid_lower_str = core::str::from_utf8(&ssid_lower).unwrap_or("");
 
-    for (i, &keyword) in SSID_KEYWORDS.iter().enumerate() {
-        if ssid_lower_str.contains(keyword) {
-            result
-                .sig_matches
-                .set(defaults::SIG_IDX_SSID_KEYWORD_START + i as u16);
-            result.add_match("ssid_keyword", keyword);
+        for (i, &keyword) in SSID_KEYWORDS.iter().enumerate() {
+            if ssid_lower_str.contains(keyword) {
+                result
+                    .sig_matches
+                    .set(defaults::SIG_IDX_SSID_KEYWORD_START + i as u16);
+                result.add_match("ssid_keyword", keyword);
+            }
         }
-    }
 
-    // WiFi name keyword check (from FlockOff — matches partial names)
-    for (i, &keyword) in WIFI_NAME_KEYWORDS.iter().enumerate() {
-        if ssid_lower_str.contains(keyword) {
-            result
-                .sig_matches
-                .set(defaults::SIG_IDX_WIFI_NAME_START + i as u16);
-            // Only add if not already matched by SSID_KEYWORDS
-            if !SSID_KEYWORDS.contains(&keyword) {
-                result.add_match("wifi_name", keyword);
+        // WiFi name keyword check (from FlockOff — matches partial names)
+        for (i, &keyword) in WIFI_NAME_KEYWORDS.iter().enumerate() {
+            if ssid_lower_str.contains(keyword) {
+                result
+                    .sig_matches
+                    .set(defaults::SIG_IDX_WIFI_NAME_START + i as u16);
+                // Only add if not already matched by SSID_KEYWORDS
+                if !SSID_KEYWORDS.contains(&keyword) {
+                    result.add_match("wifi_name", keyword);
+                }
             }
         }
     }
@@ -308,7 +310,8 @@ fn check_mac(mac: &[u8; 6], mac_index: &MacIndex, result: &mut FilterResult) {
     let lookup = mac_index.lookup(mac);
     if lookup.sig_idx != crate::mac_index::NO_ID {
         result.sig_matches.set(lookup.sig_idx);
-        result.add_match("mac_oui", lookup.vendor);
+        let vendor = defaults::vendor_for_sig_idx(lookup.sig_idx);
+        result.add_match("mac_oui", vendor);
     }
     if lookup.has_watchlist_match() {
         result.add_match("watchlist", "");
@@ -370,14 +373,11 @@ fn check_ble_ad_bytes(raw_ad: &[u8], result: &mut FilterResult) {
     }
 }
 
-/// Format a 6-byte MAC address into "AA:BB:CC:DD:EE:FF" string
+/// Format a 6-byte MAC address into "AA:BB:CC:DD:EE:FF" string.
+///
+/// Re-exported from `protocol::format_mac` for backward compatibility.
 pub fn format_mac(mac: &[u8; 6], buf: &mut crate::protocol::MacString) {
-    use core::fmt::Write;
-    let _ = write!(
-        buf,
-        "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
-        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
-    );
+    crate::protocol::format_mac(mac, buf);
 }
 
 #[cfg(test)]

--- a/src/mac_index.rs
+++ b/src/mac_index.rs
@@ -36,8 +36,6 @@ pub const NO_ID: u16 = u16::MAX;
 pub struct OuiValue {
     /// Index into `MAC_PREFIXES` array, or [`NO_ID`] if this is watchlist-only.
     pub sig_idx: u16,
-    /// Vendor name from the signature database, or empty if watchlist-only.
-    pub vendor: &'static str,
     /// Watchlist entry ID, or [`NO_ID`] if not a watchlist entry.
     pub watchlist_id: u16,
 }
@@ -66,7 +64,6 @@ impl<const N: usize> OuiIndex<N> {
             keys: [OUI_EMPTY; N],
             vals: [OuiValue {
                 sig_idx: NO_ID,
-                vendor: "",
                 watchlist_id: NO_ID,
             }; N],
             len: 0,
@@ -101,11 +98,10 @@ impl<const N: usize> OuiIndex<N> {
 
         for _ in 0..N {
             if self.keys[idx] == key {
-                // Key exists — merge: update sig_idx/vendor if they were unset,
+                // Key exists — merge: update sig_idx if unset,
                 // update watchlist_id if new value has one
                 if val.sig_idx != NO_ID {
                     self.vals[idx].sig_idx = val.sig_idx;
-                    self.vals[idx].vendor = val.vendor;
                 }
                 if val.watchlist_id != NO_ID {
                     self.vals[idx].watchlist_id = val.watchlist_id;
@@ -298,8 +294,6 @@ impl<const N: usize> FullMacIndex<N> {
 pub struct MacLookupResult {
     /// Signature index from OUI match, or `NO_ID` if none.
     pub sig_idx: u16,
-    /// Vendor name from OUI match, or empty string.
-    pub vendor: &'static str,
     /// Watchlist ID from OUI prefix match, or `NO_ID` if none.
     pub oui_watchlist_id: u16,
     /// Watchlist ID from full MAC match, or `NO_ID` if none.
@@ -368,12 +362,11 @@ impl<const OUI_CAP: usize, const MAC_CAP: usize> MacIndex<OUI_CAP, MAC_CAP> {
     /// Build the index from the default MAC_PREFIXES signature array.
     pub fn from_defaults() -> Self {
         let mut idx = Self::new();
-        for (i, &(ref prefix, vendor)) in crate::defaults::MAC_PREFIXES.iter().enumerate() {
+        for (i, &(ref prefix, _vendor)) in crate::defaults::MAC_PREFIXES.iter().enumerate() {
             idx.oui.insert(
                 *prefix,
                 OuiValue {
                     sig_idx: crate::defaults::SIG_IDX_MAC_OUI_START + i as u16,
-                    vendor,
                     watchlist_id: NO_ID,
                 },
             );
@@ -389,7 +382,6 @@ impl<const OUI_CAP: usize, const MAC_CAP: usize> MacIndex<OUI_CAP, MAC_CAP> {
 
         MacLookupResult {
             sig_idx: oui_result.map_or(NO_ID, |v| v.sig_idx),
-            vendor: oui_result.map_or("", |v| v.vendor),
             oui_watchlist_id: oui_result.map_or(NO_ID, |v| v.watchlist_id),
             full_watchlist_id: full_result.map_or(NO_ID, |v| v.watchlist_id),
         }
@@ -401,7 +393,6 @@ impl<const OUI_CAP: usize, const MAC_CAP: usize> MacIndex<OUI_CAP, MAC_CAP> {
             prefix,
             OuiValue {
                 sig_idx: NO_ID,
-                vendor: "",
                 watchlist_id,
             },
         )
@@ -453,7 +444,7 @@ mod tests {
             [0xB4, 0x1E, 0x52],
             OuiValue {
                 sig_idx: 0,
-                vendor: "Flock Safety",
+
                 watchlist_id: NO_ID,
             }
         ));
@@ -461,7 +452,7 @@ mod tests {
 
         let val = idx.get(&[0xB4, 0x1E, 0x52]).unwrap();
         assert_eq!(val.sig_idx, 0);
-        assert_eq!(val.vendor, "Flock Safety");
+
         assert_eq!(val.watchlist_id, NO_ID);
     }
 
@@ -472,7 +463,7 @@ mod tests {
             [0xB4, 0x1E, 0x52],
             OuiValue {
                 sig_idx: 0,
-                vendor: "Test",
+
                 watchlist_id: NO_ID,
             },
         );
@@ -494,7 +485,6 @@ mod tests {
                 p,
                 OuiValue {
                     sig_idx: i as u16,
-                    vendor: "Test",
                     watchlist_id: NO_ID,
                 }
             ));
@@ -513,7 +503,7 @@ mod tests {
             [0xAA, 0xBB, 0xCC],
             OuiValue {
                 sig_idx: 5,
-                vendor: "Old",
+
                 watchlist_id: NO_ID,
             },
         );
@@ -522,14 +512,14 @@ mod tests {
             [0xAA, 0xBB, 0xCC],
             OuiValue {
                 sig_idx: NO_ID,
-                vendor: "",
+
                 watchlist_id: 42,
             },
         );
         assert_eq!(idx.len(), 1); // no new entry
         let val = idx.get(&[0xAA, 0xBB, 0xCC]).unwrap();
         assert_eq!(val.sig_idx, 5); // preserved
-        assert_eq!(val.vendor, "Old"); // preserved
+
         assert_eq!(val.watchlist_id, 42); // merged
     }
 
@@ -540,7 +530,7 @@ mod tests {
             [0xAA, 0xBB, 0xCC],
             OuiValue {
                 sig_idx: 0,
-                vendor: "Test",
+
                 watchlist_id: NO_ID,
             },
         );
@@ -563,7 +553,7 @@ mod tests {
             [0xAA, 0xBB, 0xCC],
             OuiValue {
                 sig_idx: 0,
-                vendor: "A",
+
                 watchlist_id: NO_ID,
             },
         );
@@ -572,7 +562,7 @@ mod tests {
             [0xDD, 0xEE, 0xFF],
             OuiValue {
                 sig_idx: 1,
-                vendor: "B",
+
                 watchlist_id: NO_ID,
             },
         );
@@ -588,7 +578,7 @@ mod tests {
             OUI_EMPTY,
             OuiValue {
                 sig_idx: 0,
-                vendor: "",
+
                 watchlist_id: NO_ID,
             }
         ));
@@ -597,7 +587,7 @@ mod tests {
             OUI_TOMBSTONE,
             OuiValue {
                 sig_idx: 0,
-                vendor: "",
+
                 watchlist_id: NO_ID,
             }
         ));
@@ -616,7 +606,7 @@ mod tests {
             a,
             OuiValue {
                 sig_idx: 0,
-                vendor: "A",
+
                 watchlist_id: NO_ID,
             },
         );
@@ -624,7 +614,7 @@ mod tests {
             b,
             OuiValue {
                 sig_idx: 1,
-                vendor: "B",
+
                 watchlist_id: NO_ID,
             },
         );
@@ -678,7 +668,6 @@ mod tests {
         // Spot-check Flock Safety OUI
         let val = idx.oui.get(&[0xB4, 0x1E, 0x52]).unwrap();
         assert_eq!(val.sig_idx, crate::defaults::SIG_IDX_MAC_OUI_START);
-        assert_eq!(val.vendor, "Flock Safety");
     }
 
     #[test]
@@ -687,7 +676,7 @@ mod tests {
         let result = idx.lookup(&[0xB4, 0x1E, 0x52, 0x01, 0x02, 0x03]);
         assert!(result.has_match());
         assert_eq!(result.sig_idx, crate::defaults::SIG_IDX_MAC_OUI_START);
-        assert_eq!(result.vendor, "Flock Safety");
+
         assert!(!result.has_watchlist_match());
     }
 
@@ -697,7 +686,6 @@ mod tests {
         let result = idx.lookup(&[0xAA, 0xBB, 0xCC, 0x01, 0x02, 0x03]);
         assert!(!result.has_match());
         assert_eq!(result.sig_idx, NO_ID);
-        assert_eq!(result.vendor, "");
     }
 
     #[test]
@@ -742,7 +730,7 @@ mod tests {
         let result = idx.lookup(&[0xB4, 0x1E, 0x52, 0x01, 0x02, 0x03]);
         assert!(result.has_match());
         assert_eq!(result.sig_idx, crate::defaults::SIG_IDX_MAC_OUI_START);
-        assert_eq!(result.vendor, "Flock Safety");
+
         assert_eq!(result.oui_watchlist_id, 99);
     }
 

--- a/src/mac_index.rs
+++ b/src/mac_index.rs
@@ -100,7 +100,7 @@ impl<const N: usize> OuiIndex<N> {
             if self.keys[idx] == key {
                 // Key exists — merge: update sig_idx if unset,
                 // update watchlist_id if new value has one
-                if val.sig_idx != NO_ID {
+                if self.vals[idx].sig_idx == NO_ID && val.sig_idx != NO_ID {
                     self.vals[idx].sig_idx = val.sig_idx;
                 }
                 if val.watchlist_id != NO_ID {

--- a/src/odid.rs
+++ b/src/odid.rs
@@ -12,6 +12,20 @@ const MESSAGE_SIZE: usize = 25;
 /// BLE service data UUID for ODID (little-endian: 0xFA, 0xFF).
 const ODID_BLE_UUID: [u8; 2] = [0xFA, 0xFF];
 
+/// Decode a null-terminated ASCII printable string from raw ODID ID bytes.
+fn decode_ascii_id<const N: usize>(id_bytes: &[u8]) -> heapless::String<N> {
+    let mut s = heapless::String::new();
+    for &b in id_bytes {
+        if b == 0 {
+            break;
+        }
+        if b >= 0x20 && b <= 0x7E {
+            let _ = s.push(b as char);
+        }
+    }
+    s
+}
+
 /// WiFi vendor IE OUI for ODID (ASTM).
 const ODID_WIFI_OUI: [u8; 3] = [0x90, 0x3A, 0xE6];
 
@@ -469,16 +483,7 @@ pub fn decode_basic_id(data: &[u8]) -> Option<BasicId> {
     let id_type = IdType::from_nibble(data[1] >> 4);
     let id_bytes = &data[2..22];
 
-    let mut uas_id = heapless::String::new();
-    for &b in id_bytes {
-        if b == 0 {
-            break;
-        }
-        // Only accept printable ASCII
-        if b >= 0x20 && b <= 0x7E {
-            let _ = uas_id.push(b as char);
-        }
-    }
+    let uas_id = decode_ascii_id(id_bytes);
 
     Some(BasicId {
         ua_type,
@@ -632,15 +637,7 @@ pub fn decode_operator_id(data: &[u8]) -> Option<OperatorId> {
     let operator_id_type = data[1];
     let id_bytes = &data[2..22];
 
-    let mut operator_id = heapless::String::new();
-    for &b in id_bytes {
-        if b == 0 {
-            break;
-        }
-        if b >= 0x20 && b <= 0x7E {
-            let _ = operator_id.push(b as char);
-        }
-    }
+    let operator_id = decode_ascii_id(id_bytes);
 
     Some(OperatorId {
         operator_id_type,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -239,6 +239,7 @@ pub(crate) struct RawCommand {
 /// Format a 6-byte MAC address into "AA:BB:CC:DD:EE:FF" string.
 pub fn format_mac(mac: &[u8; 6], buf: &mut MacString) {
     use core::fmt::Write;
+    buf.clear();
     let _ = write!(
         buf,
         "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -236,6 +236,16 @@ pub(crate) struct RawCommand {
     pub category: Option<heapless::String<16>>,
 }
 
+/// Format a 6-byte MAC address into "AA:BB:CC:DD:EE:FF" string.
+pub fn format_mac(mac: &[u8; 6], buf: &mut MacString) {
+    use core::fmt::Write;
+    let _ = write!(
+        buf,
+        "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+    );
+}
+
 /// Firmware version string
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -181,10 +181,8 @@ fn build_wifi_event(
     let _ = ssid_str.push_str(ssid);
     #[cfg(not(feature = "esp32"))]
     let raw_ies = {
-        let mut v = Vec::new();
-        for &b in ies.iter().take(64) {
-            let _ = v.push(b);
-        }
+        let mut v: Vec<u8, 64> = Vec::new();
+        v.extend(ies.iter().copied().take(64));
         v
     };
     WiFiEvent {
@@ -251,10 +249,8 @@ pub fn try_parse_odid_nan(frame: &[u8], rssi: i8, _channel: u8) -> Option<OdidEv
     let service_info = extract_nan_odid_service_info(nan_body)?;
 
     // Store raw service info bytes — parsing deferred to filter task
-    let mut raw_data = heapless::Vec::new();
-    for &b in service_info.iter().take(64) {
-        let _ = raw_data.push(b);
-    }
+    let mut raw_data: heapless::Vec<u8, 64> = heapless::Vec::new();
+    raw_data.extend(service_info.iter().copied().take(64));
 
     Some(OdidEvent {
         source: OdidSource::WiFiNan,
@@ -371,10 +367,8 @@ impl BleAdvParser {
     /// `rssi` is the received signal strength.
     /// `ad_data` is the raw advertisement data bytes.
     pub fn parse(addr: &[u8; 6], rssi: i8, ad_data: &[u8]) -> BleEvent {
-        let mut raw_ad = Vec::new();
-        for &b in ad_data.iter().take(62) {
-            let _ = raw_ad.push(b);
-        }
+        let mut raw_ad: Vec<u8, 62> = Vec::new();
+        raw_ad.extend(ad_data.iter().copied().take(62));
 
         let mut event = BleEvent {
             mac: *addr,


### PR DESCRIPTION
## Summary
- Remove `&'static str vendor` field from `OuiValue` and `MacLookupResult`, recovering vendor name at emit time via `defaults::vendor_for_sig_idx()`. Saves ~512B–1KB DRAM on ESP32 (8 bytes per slot × 128 OUI slots).
- Consolidate `format_mac` into `protocol.rs` as canonical location; `filter::format_mac` now delegates.
- Skip SSID keyword scan when SSID is empty (minor perf).
- Extract `decode_ascii_id` helper in `odid.rs` (DRY).
- Use idiomatic `Vec::extend` in `scanner.rs`.

## Test plan
- [x] `cargo test --lib --no-default-features` — all 297 tests pass
- [x] `cargo fmt --check` — clean
- [ ] `just docker-check` — type-check both ESP32 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)