### PR TITLE
ci: use GitHub App token for release-please PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,21 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # The release PR is opened with an installation token minted from the
+      # release-please GitHub App instead of GITHUB_TOKEN, so the pull_request
+      # workflows behind CI checks actually run on it (GITHUB_TOKEN-authored
+      # events never trigger downstream workflows).
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

`release.yml` currently runs `googleapis/release-please-action` with no explicit `token:`, so it falls back to the default `GITHUB_TOKEN`. That means any release PR release-please opens is authored by `github-actions[bot]`.

GitHub does not trigger `pull_request` workflows from events authored by `GITHUB_TOKEN` (to prevent recursive workflow loops). Concretely, this repo's `ci.yml` runs `commitlint`, `fmt`, `schemas`, `test`, `audit`, `build`, etc. on `pull_request`, none of which run automatically on a release-please PR today — if branch protection required any of these checks, the release PR could become impossible to merge without manually re-triggering CI.

Note: `main` currently has **no branch protection** configured on this repo (`gh api repos/dougborg/AirHound/branches/main/protection` returns 404), so this isn't fixing an active blocker right now — it's closing a gap that would otherwise bite the moment required status checks are turned on, and it also gives release PRs the same CI signal as any other PR in the meantime.

## What changed

- Added a step that mints a short-lived installation token from the `dougborg-release-please` GitHub App (already installed on this repo; credentials already configured as the `RELEASE_PLEASE_APP_ID` variable and `RELEASE_PLEASE_APP_PRIVATE_KEY` secret — no secrets/variables were touched by this PR).
- Passed that token to `googleapis/release-please-action` via `token:`.
- Pinned `actions/create-github-app-token` to `bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3`, consistent with this repo's SHA-pinning convention.
- Left `build-release` and `publish-release` untouched — artifact upload/download and the `softprops/action-gh-release` release-asset publishing continue to use `GITHUB_TOKEN` exactly as before. No package-registry or OIDC auth was touched.

Reference implementation: `dougborg/harness-kit`'s `.github/workflows/release-please.yml`, adapted here to fit AirHound's multi-job artifact-build/publish structure (harness-kit's workflow only has the single release-please job).

## Test plan

- [x] `actionlint .github/workflows/release.yml` passes with no findings
- [ ] On merge, next `push` to `main` should open/update the release PR authored by the `dougborg-release-please[bot]` app instead of `github-actions[bot]`, and CI should run on that PR