### PR TITLE
fix(release): attach firmware before publishing, for immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,12 @@ jobs:
           pattern: release-bin-*
           merge-multiple: true
 
+      # release-please creates the release as a draft (draft: true in
+      # release-please-config.json). Immutable releases reject asset uploads
+      # once a release is published, so the binaries have to go on while it is
+      # still a draft — this step attaches them and publishes in one call.
       - uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: "*.bin"
+          draft: false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
     ".": {
       "release-type": "rust",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "draft": true
     }
   }
 }


### PR DESCRIPTION
## Problem

Merging #121 cut `airhound-v0.1.1`, both firmware builds succeeded, and then `publish-release` failed in run [30205005779](https://github.com/dougborg/AirHound/actions/runs/30205005779):

```
##[error]Cannot upload assets to an immutable release. - https://docs.github.com/rest
```

**`airhound-v0.1.1` therefore shipped with no `.bin` files attached.**

Immutable releases are enabled on this repo. A published release cannot accept new assets — they must be present before publication. The workflow did the opposite: `release-please` created *and published* the release, and `softprops/action-gh-release` then tried to attach the binaries to it.

The build order is not the problem — `publish-release` correctly waits on `build-release`. The problem is that the release is already published by the time the assets exist.

## Fix

1. `release-please-config.json` — add `"draft": true`, so release-please creates the release as a draft and does not publish it.
2. `release.yml` — `softprops/action-gh-release` gains `draft: false`, so the same call that uploads the `.bin` files also flips the release to published.

That produces the draft → upload → publish sequence immutability requires, while keeping release-please as the owner of versioning and release notes.

## Note on the tag

A draft release does not create its git tag until it is published, so the `airhound-v*` tag now appears at publish time rather than at release-please time. If `publish-release` fails, no tag is created and the run can simply be retried — which is arguably better than today, where a failed publish leaves a tagged release with missing artifacts.

## v0.1.1

Cannot be repaired: the release is immutable, so the binaries can never be attached to it. They do survive as workflow artifacts on run 30205005779 if they are needed. The next release will attach them normally.

## Related

This is the same failure class as `stocktrim-openapi-client`#237, which hit it via `gh release upload --clobber` against a python-semantic-release-published release. Same cause, different tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ